### PR TITLE
SongDetails v3 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ mod.json
 *.~cpp
 *.~hpp
 vcpkg_installed/
+cmake-build-debug/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ mod.json
 vcpkg_installed/
 cmake-build-debug/
 .idea/
+ndkpath.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "include/gzip-hpp"]
-	path = include/gzip-hpp
-	url = https://github.com/mapbox/gzip-hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(
     unofficial::brotli::brotlidec
     protobuf::libprotobuf
     ${EXTERN_DIR}/libs/libcurl.a
-    ${EXTERN_DIR}/libs/libpaperlog.so
+    ${EXTERN_DIR}/libs/libpaper2_scotland2.so
 )
 
 add_custom_command(TARGET ${COMPILE_ID} POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,22 @@ cmake_minimum_required(VERSION 3.22)
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/quest.cmake)
 
+# get the vcpkg dir from env variables
+if(EXISTS $ENV{VCPKG_ROOT})
+    set(VCPKG_ROOT $ENV{VCPKG_ROOT})
+else()
+    MESSAGE(ERROR "Please define the environment variable VCPKG_ROOT with the root to your vcpkg install!")
+endif()
+
+# vcpkg config. Must be before project
+message("VCPKG $ENV{VCPKG_ROOT}")
+set(VCPKG_TARGET_TRIPLET arm64-android)
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${CMAKE_ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+set(VCPKG_MANIFEST_DIR ${CMAKE_SOURCE_DIR})
+set(VCPKG_INSTALLED_DIR ${CMAKE_SOURCE_DIR}/vcpkg_installed)
+string(REPLACE "\\" "/" VCPKG_ROOT_WINDOWS_FIX $ENV{VCPKG_ROOT})
+set(CMAKE_TOOLCHAIN_FILE ${VCPKG_ROOT_WINDOWS_FIX}/scripts/buildsystems/vcpkg.cmake)
+
 project(${PACKAGE_ID} VERSION ${PACKAGE_VERSION})
 
 # c++ standard
@@ -38,14 +54,10 @@ add_library(
     ${CMAKE_SOURCE_DIR}/src/SongProto.pb.cc # it ends in .cc so add it manually
 )
 
-# get the vcpkg dir from env variables
-if(EXISTS $ENV{VCPKG_ROOT})
-    set(VCPKG_ROOT $ENV{VCPKG_ROOT})
-else()
-    MESSAGE(ERROR "Please define the environment variable VCPKG_ROOT with the root to your vcpkg install!")
-endif()
-
 target_include_directories(${COMPILE_ID} PRIVATE "${VCPKG_ROOT}/installed/arm64-android/include")
+
+find_package(unofficial-brotli CONFIG REQUIRED)
+find_package(protobuf CONFIG REQUIRED)
 
 # add src dir as include dir
 target_include_directories(${COMPILE_ID} PRIVATE ${SOURCE_DIR})
@@ -65,7 +77,9 @@ target_link_libraries(
     PRIVATE
     -llog
     -lz
-    "${VCPKG_ROOT}/installed/arm64-android/lib/libprotobuf.a"
+    unofficial::brotli::brotlidec
+    unofficial::brotli::brotlienc
+    protobuf::libprotobuf
     ${EXTERN_DIR}/libs/libcurl.a
     ${EXTERN_DIR}/libs/libpaperlog.so
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ project(${PACKAGE_ID} VERSION ${PACKAGE_VERSION})
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 
 # define that stores the actual source directory
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -33,6 +32,17 @@ set(COMPILE_ID songdetails)
 
 # compile options used
 add_compile_options(-frtti -fPIE -fPIC -fexceptions -fvisibility=hidden)
+
+if(${CMAKE_BUILD_TYPE} STREQUAL "RELEASE" OR ${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo" OR ${CMAKE_BUILD_TYPE} STREQUAL "MinSizeRel")
+    
+    # Better optimizations
+    add_compile_options(-O3)
+
+    # LTO
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    add_compile_options(-flto)
+endif()
+
 # compile definitions used
 add_compile_definitions(VERSION=\"${PACKAGE_VERSION}\")
 add_compile_definitions(MOD_ID=\"${PACKAGE_ID}\")
@@ -65,8 +75,6 @@ target_include_directories(${COMPILE_ID} PRIVATE ${SOURCE_DIR})
 target_include_directories(${COMPILE_ID} PRIVATE ${INCLUDE_DIR})
 # add shared dir as include dir
 target_include_directories(${COMPILE_ID} PUBLIC ${SHARED_DIR})
-# gzip library
-target_include_directories(${COMPILE_ID} PRIVATE ${INCLUDE_DIR}/gzip-hpp/include)
 
 target_include_directories(${COMPILE_ID} PRIVATE ${EXTERN_DIR}/includes)
 target_include_directories(${COMPILE_ID} SYSTEM PRIVATE ${EXTERN_DIR}/includes/libil2cpp/il2cpp/libil2cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ target_link_libraries(
     -llog
     -lz
     unofficial::brotli::brotlidec
-    unofficial::brotli::brotlienc
     protobuf::libprotobuf
     ${EXTERN_DIR}/libs/libcurl.a
     ${EXTERN_DIR}/libs/libpaperlog.so

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When cloning the repo make sure to clone with submodules, as a submodule is used
 I'm not going to give all the build instructions, since most are the same for beat saber mods, you just have to make sure you have a vcpkg install and that you run
 
 ```shell
-vcpkg install protobuf:arm64-android
+vcpkg install --triplet arm64-android
 ```
 
 Then you should be able to update the VCPKG path in the CMakeLists.txt file so that it can find the protobuf package, this is obviously not the most neat way of doing this but it's what worked for now till I improve it

--- a/cmake/quest.cmake
+++ b/cmake/quest.cmake
@@ -1,5 +1,5 @@
 if (NOT DEFINED CMAKE_ANDROID_NDK)
-	if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/ndkpath.txt")
+	if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/../ndkpath.txt")
 		file (STRINGS "ndkpath.txt" CMAKE_ANDROID_NDK)
 	else()
 		if(EXISTS $ENV{ANDROID_NDK_HOME})

--- a/include/Data/DataGetter.hpp
+++ b/include/Data/DataGetter.hpp
@@ -27,6 +27,7 @@ namespace SongDetailsCache {
             static std::filesystem::path basePath;
             friend class SongDetails;
             static void WriteCachedDatabase_internal(DownloadedDatabase& db);
+            static bool DecompressBrotli(std::vector<uint8_t>& out, std::string const& in);
             static std::optional<DownloadedDatabase> UpdateAndReadDatabase_internal(std::string_view dataSourceName = "Direct");
     };
 }

--- a/include/Data/SongDetailsContainer.hpp
+++ b/include/Data/SongDetailsContainer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "beatsaber-hook/shared/utils/typedefs-wrappers.hpp"
+#include "bshook-utils.hpp"
 #include <stdint.h>
 #include <vector>
 #include <future>
@@ -75,8 +75,8 @@ namespace SongDetailsCache {
 
             static bool get_isDataAvailable() { return songs && !songs->empty(); }
 
-            static UnorderedEventCallback<> dataAvailableOrUpdatedInternal;
-            static UnorderedEventCallback<std::string> dataLoadFailedInternal;
+            static BSHookUtils::UnorderedEventCallback<> dataAvailableOrUpdatedInternal;
+            static BSHookUtils::UnorderedEventCallback<std::string> dataLoadFailedInternal;
             static void Load_internal(bool reload, int acceptableAgeHours);
             static void Process(const std::vector<uint8_t>& data, bool force = true);
             static void Process(std::istream& istream, bool force = true);

--- a/include/Data/SongDetailsContainer.hpp
+++ b/include/Data/SongDetailsContainer.hpp
@@ -21,7 +21,7 @@ namespace SongDetailsCache {
     using shared_ptr_unordered_map = std::shared_ptr<std::unordered_map<T, U>>;
 
     template<typename T, typename U>
-    inline shared_ptr_unordered_map<T, U> make_shared_map() { return std::make_shared<std::unordered_map<T, U>>(); }
+    inline shared_ptr_unordered_map<T, U> make_shared_unordered_map() { return std::make_shared<std::unordered_map<T, U>>(); }
 
     namespace Structs {
         class SongProtoContainer;

--- a/include/Data/SongDetailsContainer.hpp
+++ b/include/Data/SongDetailsContainer.hpp
@@ -18,10 +18,10 @@ namespace SongDetailsCache {
     inline shared_ptr_vector<T> make_shared_vec() { return std::make_shared<std::vector<T>>(); }
 
     template<typename T, typename U>
-    using shared_ptr_map = std::shared_ptr<std::map<T, U>>;
+    using shared_ptr_unordered_map = std::shared_ptr<std::unordered_map<T, U>>;
 
     template<typename T, typename U>
-    inline shared_ptr_map<T, U> make_shared_map() { return std::make_shared<std::map<T, U>>(); }
+    inline shared_ptr_unordered_map<T, U> make_shared_map() { return std::make_shared<std::unordered_map<T, U>>(); }
 
     namespace Structs {
         class SongProtoContainer;
@@ -65,7 +65,7 @@ namespace SongDetailsCache {
             static shared_ptr_vector<std::string> songAuthorNames;
             static shared_ptr_vector<std::string> levelAuthorNames;
             static shared_ptr_vector<std::string> uploaderNames;
-            static shared_ptr_map<std::string, uint64_t> tags;
+            static shared_ptr_unordered_map<std::string, uint64_t> tags;
 
             static std::chrono::sys_seconds scrapeEndedTimeUnix;
             static std::chrono::seconds updateThrottle;

--- a/include/Data/SongDetailsContainer.hpp
+++ b/include/Data/SongDetailsContainer.hpp
@@ -76,7 +76,7 @@ namespace SongDetailsCache {
             static bool get_isDataAvailable() { return songs && !songs->empty(); }
 
             static UnorderedEventCallback<> dataAvailableOrUpdatedInternal;
-            static UnorderedEventCallback<> dataLoadFailedInternal;
+            static UnorderedEventCallback<std::string> dataLoadFailedInternal;
             static void Load_internal(bool reload, int acceptableAgeHours);
             static void Process(const std::vector<uint8_t>& data, bool force = true);
             static void Process(std::istream& istream, bool force = true);

--- a/include/Data/SongDetailsContainer.hpp
+++ b/include/Data/SongDetailsContainer.hpp
@@ -16,6 +16,13 @@ namespace SongDetailsCache {
 
     template<typename T>
     inline shared_ptr_vector<T> make_shared_vec() { return std::make_shared<std::vector<T>>(); }
+
+    template<typename T, typename U>
+    using shared_ptr_map = std::shared_ptr<std::map<T, U>>;
+
+    template<typename T, typename U>
+    inline shared_ptr_map<T, U> make_shared_map() { return std::make_shared<std::map<T, U>>(); }
+
     namespace Structs {
         class SongProtoContainer;
     }
@@ -58,6 +65,7 @@ namespace SongDetailsCache {
             static shared_ptr_vector<std::string> songAuthorNames;
             static shared_ptr_vector<std::string> levelAuthorNames;
             static shared_ptr_vector<std::string> uploaderNames;
+            static shared_ptr_map<std::string, uint64_t> tags;
 
             static std::chrono::sys_seconds scrapeEndedTimeUnix;
             static std::chrono::seconds updateThrottle;

--- a/include/Data/SongDetailsContainer.hpp
+++ b/include/Data/SongDetailsContainer.hpp
@@ -6,6 +6,7 @@
 #include <future>
 #include <istream>
 #include <chrono>
+#include <SongProto.pb.h>
 
 #include "Data/Song.hpp"
 
@@ -71,6 +72,6 @@ namespace SongDetailsCache {
             static void Load_internal(bool reload, int acceptableAgeHours);
             static void Process(const std::vector<uint8_t>& data, bool force = true);
             static void Process(std::istream& istream, bool force = true);
-            static void Process(const Structs::SongProtoContainer& parsedContainer, bool force = true);
+            static void Process(const Structs::SongDetailsV3& parsedContainer, bool force = true);
     };
 }

--- a/include/SongProto.pb.h
+++ b/include/SongProto.pb.h
@@ -29,6 +29,7 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>  // IWYU pragma: export
 #include <google/protobuf/extension_set.h>  // IWYU pragma: export
+#include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
 // @@protoc_insertion_point(includes)
 #include <google/protobuf/port_def.inc>
@@ -46,45 +47,158 @@ struct TableStruct_SongProto_2eproto {
 extern const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_SongProto_2eproto;
 namespace SongDetailsCache {
 namespace Structs {
-class SongDifficultyProto;
-struct SongDifficultyProtoDefaultTypeInternal;
-extern SongDifficultyProtoDefaultTypeInternal _SongDifficultyProto_default_instance_;
-class SongProto;
-struct SongProtoDefaultTypeInternal;
-extern SongProtoDefaultTypeInternal _SongProto_default_instance_;
-class SongProtoContainer;
-struct SongProtoContainerDefaultTypeInternal;
-extern SongProtoContainerDefaultTypeInternal _SongProtoContainer_default_instance_;
+class SongDetailsV3;
+struct SongDetailsV3DefaultTypeInternal;
+extern SongDetailsV3DefaultTypeInternal _SongDetailsV3_default_instance_;
+class SongDifficulty;
+struct SongDifficultyDefaultTypeInternal;
+extern SongDifficultyDefaultTypeInternal _SongDifficulty_default_instance_;
+class SongV3;
+struct SongV3DefaultTypeInternal;
+extern SongV3DefaultTypeInternal _SongV3_default_instance_;
 }  // namespace Structs
 }  // namespace SongDetailsCache
 PROTOBUF_NAMESPACE_OPEN
-template<> ::SongDetailsCache::Structs::SongDifficultyProto* Arena::CreateMaybeMessage<::SongDetailsCache::Structs::SongDifficultyProto>(Arena*);
-template<> ::SongDetailsCache::Structs::SongProto* Arena::CreateMaybeMessage<::SongDetailsCache::Structs::SongProto>(Arena*);
-template<> ::SongDetailsCache::Structs::SongProtoContainer* Arena::CreateMaybeMessage<::SongDetailsCache::Structs::SongProtoContainer>(Arena*);
+template<> ::SongDetailsCache::Structs::SongDetailsV3* Arena::CreateMaybeMessage<::SongDetailsCache::Structs::SongDetailsV3>(Arena*);
+template<> ::SongDetailsCache::Structs::SongDifficulty* Arena::CreateMaybeMessage<::SongDetailsCache::Structs::SongDifficulty>(Arena*);
+template<> ::SongDetailsCache::Structs::SongV3* Arena::CreateMaybeMessage<::SongDetailsCache::Structs::SongV3>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
 namespace SongDetailsCache {
 namespace Structs {
 
+enum SongDifficulty_MapCharacteristic : int {
+  SongDifficulty_MapCharacteristic_Custom = 0,
+  SongDifficulty_MapCharacteristic_Standard = 1,
+  SongDifficulty_MapCharacteristic_OneSaber = 2,
+  SongDifficulty_MapCharacteristic_NoArrows = 3,
+  SongDifficulty_MapCharacteristic_NinetyDegree = 4,
+  SongDifficulty_MapCharacteristic_ThreeSixtyDegree = 5,
+  SongDifficulty_MapCharacteristic_Lightshow = 6,
+  SongDifficulty_MapCharacteristic_Lawless = 7,
+  SongDifficulty_MapCharacteristic_SongDifficulty_MapCharacteristic_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
+  SongDifficulty_MapCharacteristic_SongDifficulty_MapCharacteristic_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
+};
+bool SongDifficulty_MapCharacteristic_IsValid(int value);
+constexpr SongDifficulty_MapCharacteristic SongDifficulty_MapCharacteristic_MapCharacteristic_MIN = SongDifficulty_MapCharacteristic_Custom;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty_MapCharacteristic_MapCharacteristic_MAX = SongDifficulty_MapCharacteristic_Lawless;
+constexpr int SongDifficulty_MapCharacteristic_MapCharacteristic_ARRAYSIZE = SongDifficulty_MapCharacteristic_MapCharacteristic_MAX + 1;
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* SongDifficulty_MapCharacteristic_descriptor();
+template<typename T>
+inline const std::string& SongDifficulty_MapCharacteristic_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, SongDifficulty_MapCharacteristic>::value ||
+    ::std::is_integral<T>::value,
+    "Incorrect type passed to function SongDifficulty_MapCharacteristic_Name.");
+  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
+    SongDifficulty_MapCharacteristic_descriptor(), enum_t_value);
+}
+inline bool SongDifficulty_MapCharacteristic_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, SongDifficulty_MapCharacteristic* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<SongDifficulty_MapCharacteristic>(
+    SongDifficulty_MapCharacteristic_descriptor(), name, value);
+}
+enum SongDifficulty_MapDifficulty : int {
+  SongDifficulty_MapDifficulty_Easy = 0,
+  SongDifficulty_MapDifficulty_Normal = 1,
+  SongDifficulty_MapDifficulty_Hard = 2,
+  SongDifficulty_MapDifficulty_Expert = 3,
+  SongDifficulty_MapDifficulty_ExpertPlus = 4,
+  SongDifficulty_MapDifficulty_SongDifficulty_MapDifficulty_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
+  SongDifficulty_MapDifficulty_SongDifficulty_MapDifficulty_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
+};
+bool SongDifficulty_MapDifficulty_IsValid(int value);
+constexpr SongDifficulty_MapDifficulty SongDifficulty_MapDifficulty_MapDifficulty_MIN = SongDifficulty_MapDifficulty_Easy;
+constexpr SongDifficulty_MapDifficulty SongDifficulty_MapDifficulty_MapDifficulty_MAX = SongDifficulty_MapDifficulty_ExpertPlus;
+constexpr int SongDifficulty_MapDifficulty_MapDifficulty_ARRAYSIZE = SongDifficulty_MapDifficulty_MapDifficulty_MAX + 1;
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* SongDifficulty_MapDifficulty_descriptor();
+template<typename T>
+inline const std::string& SongDifficulty_MapDifficulty_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, SongDifficulty_MapDifficulty>::value ||
+    ::std::is_integral<T>::value,
+    "Incorrect type passed to function SongDifficulty_MapDifficulty_Name.");
+  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
+    SongDifficulty_MapDifficulty_descriptor(), enum_t_value);
+}
+inline bool SongDifficulty_MapDifficulty_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, SongDifficulty_MapDifficulty* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<SongDifficulty_MapDifficulty>(
+    SongDifficulty_MapDifficulty_descriptor(), name, value);
+}
+enum RankedStatusBitflags : int {
+  Unranked = 0,
+  RankedSS = 1,
+  RankedBL = 2,
+  QualifiedSS = 4,
+  QualifiedBL = 8,
+  RankedStatusBitflags_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
+  RankedStatusBitflags_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
+};
+bool RankedStatusBitflags_IsValid(int value);
+constexpr RankedStatusBitflags RankedStatusBitflags_MIN = Unranked;
+constexpr RankedStatusBitflags RankedStatusBitflags_MAX = QualifiedBL;
+constexpr int RankedStatusBitflags_ARRAYSIZE = RankedStatusBitflags_MAX + 1;
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* RankedStatusBitflags_descriptor();
+template<typename T>
+inline const std::string& RankedStatusBitflags_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, RankedStatusBitflags>::value ||
+    ::std::is_integral<T>::value,
+    "Incorrect type passed to function RankedStatusBitflags_Name.");
+  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
+    RankedStatusBitflags_descriptor(), enum_t_value);
+}
+inline bool RankedStatusBitflags_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, RankedStatusBitflags* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<RankedStatusBitflags>(
+    RankedStatusBitflags_descriptor(), name, value);
+}
+enum UploadFlags : int {
+  None = 0,
+  VerifiedUploader = 1,
+  Curated = 2,
+  UploadFlags_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
+  UploadFlags_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
+};
+bool UploadFlags_IsValid(int value);
+constexpr UploadFlags UploadFlags_MIN = None;
+constexpr UploadFlags UploadFlags_MAX = Curated;
+constexpr int UploadFlags_ARRAYSIZE = UploadFlags_MAX + 1;
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* UploadFlags_descriptor();
+template<typename T>
+inline const std::string& UploadFlags_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, UploadFlags>::value ||
+    ::std::is_integral<T>::value,
+    "Incorrect type passed to function UploadFlags_Name.");
+  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
+    UploadFlags_descriptor(), enum_t_value);
+}
+inline bool UploadFlags_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, UploadFlags* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<UploadFlags>(
+    UploadFlags_descriptor(), name, value);
+}
 // ===================================================================
 
-class SongDifficultyProto final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:SongDetailsCache.Structs.SongDifficultyProto) */ {
+class SongDetailsV3 final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:SongDetailsCache.Structs.SongDetailsV3) */ {
  public:
-  inline SongDifficultyProto() : SongDifficultyProto(nullptr) {}
-  ~SongDifficultyProto() override;
-  explicit PROTOBUF_CONSTEXPR SongDifficultyProto(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline SongDetailsV3() : SongDetailsV3(nullptr) {}
+  ~SongDetailsV3() override;
+  explicit PROTOBUF_CONSTEXPR SongDetailsV3(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  SongDifficultyProto(const SongDifficultyProto& from);
-  SongDifficultyProto(SongDifficultyProto&& from) noexcept
-    : SongDifficultyProto() {
+  SongDetailsV3(const SongDetailsV3& from);
+  SongDetailsV3(SongDetailsV3&& from) noexcept
+    : SongDetailsV3() {
     *this = ::std::move(from);
   }
 
-  inline SongDifficultyProto& operator=(const SongDifficultyProto& from) {
+  inline SongDetailsV3& operator=(const SongDetailsV3& from) {
     CopyFrom(from);
     return *this;
   }
-  inline SongDifficultyProto& operator=(SongDifficultyProto&& from) noexcept {
+  inline SongDetailsV3& operator=(SongDetailsV3&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()
   #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
@@ -107,20 +221,20 @@ class SongDifficultyProto final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const SongDifficultyProto& default_instance() {
+  static const SongDetailsV3& default_instance() {
     return *internal_default_instance();
   }
-  static inline const SongDifficultyProto* internal_default_instance() {
-    return reinterpret_cast<const SongDifficultyProto*>(
-               &_SongDifficultyProto_default_instance_);
+  static inline const SongDetailsV3* internal_default_instance() {
+    return reinterpret_cast<const SongDetailsV3*>(
+               &_SongDetailsV3_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     0;
 
-  friend void swap(SongDifficultyProto& a, SongDifficultyProto& b) {
+  friend void swap(SongDetailsV3& a, SongDetailsV3& b) {
     a.Swap(&b);
   }
-  inline void Swap(SongDifficultyProto* other) {
+  inline void Swap(SongDetailsV3* other) {
     if (other == this) return;
   #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
     if (GetOwningArena() != nullptr &&
@@ -133,7 +247,7 @@ class SongDifficultyProto final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(SongDifficultyProto* other) {
+  void UnsafeArenaSwap(SongDetailsV3* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -141,14 +255,14 @@ class SongDifficultyProto final :
 
   // implements Message ----------------------------------------------
 
-  SongDifficultyProto* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<SongDifficultyProto>(arena);
+  SongDetailsV3* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<SongDetailsV3>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const SongDifficultyProto& from);
+  void CopyFrom(const SongDetailsV3& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom( const SongDifficultyProto& from) {
-    SongDifficultyProto::MergeImpl(*this, from);
+  void MergeFrom( const SongDetailsV3& from) {
+    SongDetailsV3::MergeImpl(*this, from);
   }
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
@@ -166,15 +280,15 @@ class SongDifficultyProto final :
   void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(SongDifficultyProto* other);
+  void InternalSwap(SongDetailsV3* other);
 
   private:
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "SongDetailsCache.Structs.SongDifficultyProto";
+    return "SongDetailsCache.Structs.SongDetailsV3";
   }
   protected:
-  explicit SongDifficultyProto(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit SongDetailsV3(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   public:
 
@@ -188,110 +302,87 @@ class SongDifficultyProto final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kCharacteristicFieldNumber = 1,
-    kDifficultyFieldNumber = 2,
-    kStarsT100FieldNumber = 4,
-    kStarsT100BLFieldNumber = 5,
-    kNjsT100FieldNumber = 6,
-    kBombsFieldNumber = 7,
-    kNotesFieldNumber = 8,
-    kObstaclesFieldNumber = 9,
-    kModsFieldNumber = 10,
+    kSongsFieldNumber = 4,
+    kTagListFieldNumber = 5,
+    kSongHashesFieldNumber = 3,
+    kFormatVersionFieldNumber = 1,
+    kScrapeEndedUnixFieldNumber = 2,
   };
-  // optional uint32 characteristic = 1;
-  bool has_characteristic() const;
+  // repeated .SongDetailsCache.Structs.SongV3 songs = 4;
+  int songs_size() const;
   private:
-  bool _internal_has_characteristic() const;
+  int _internal_songs_size() const;
   public:
-  void clear_characteristic();
-  uint32_t characteristic() const;
-  void set_characteristic(uint32_t value);
+  void clear_songs();
+  ::SongDetailsCache::Structs::SongV3* mutable_songs(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongV3 >*
+      mutable_songs();
   private:
-  uint32_t _internal_characteristic() const;
-  void _internal_set_characteristic(uint32_t value);
+  const ::SongDetailsCache::Structs::SongV3& _internal_songs(int index) const;
+  ::SongDetailsCache::Structs::SongV3* _internal_add_songs();
+  public:
+  const ::SongDetailsCache::Structs::SongV3& songs(int index) const;
+  ::SongDetailsCache::Structs::SongV3* add_songs();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongV3 >&
+      songs() const;
+
+  // repeated string tagList = 5;
+  int taglist_size() const;
+  private:
+  int _internal_taglist_size() const;
+  public:
+  void clear_taglist();
+  const std::string& taglist(int index) const;
+  std::string* mutable_taglist(int index);
+  void set_taglist(int index, const std::string& value);
+  void set_taglist(int index, std::string&& value);
+  void set_taglist(int index, const char* value);
+  void set_taglist(int index, const char* value, size_t size);
+  std::string* add_taglist();
+  void add_taglist(const std::string& value);
+  void add_taglist(std::string&& value);
+  void add_taglist(const char* value);
+  void add_taglist(const char* value, size_t size);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>& taglist() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>* mutable_taglist();
+  private:
+  const std::string& _internal_taglist(int index) const;
+  std::string* _internal_add_taglist();
   public:
 
-  // optional uint32 difficulty = 2;
-  bool has_difficulty() const;
+  // bytes songHashes = 3;
+  void clear_songhashes();
+  const std::string& songhashes() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_songhashes(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_songhashes();
+  PROTOBUF_NODISCARD std::string* release_songhashes();
+  void set_allocated_songhashes(std::string* songhashes);
   private:
-  bool _internal_has_difficulty() const;
-  public:
-  void clear_difficulty();
-  uint32_t difficulty() const;
-  void set_difficulty(uint32_t value);
-  private:
-  uint32_t _internal_difficulty() const;
-  void _internal_set_difficulty(uint32_t value);
-  public:
-
-  // uint32 starsT100 = 4;
-  void clear_starst100();
-  uint32_t starst100() const;
-  void set_starst100(uint32_t value);
-  private:
-  uint32_t _internal_starst100() const;
-  void _internal_set_starst100(uint32_t value);
+  const std::string& _internal_songhashes() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_songhashes(const std::string& value);
+  std::string* _internal_mutable_songhashes();
   public:
 
-  // uint32 starsT100BL = 5;
-  void clear_starst100bl();
-  uint32_t starst100bl() const;
-  void set_starst100bl(uint32_t value);
+  // uint32 formatVersion = 1;
+  void clear_formatversion();
+  uint32_t formatversion() const;
+  void set_formatversion(uint32_t value);
   private:
-  uint32_t _internal_starst100bl() const;
-  void _internal_set_starst100bl(uint32_t value);
+  uint32_t _internal_formatversion() const;
+  void _internal_set_formatversion(uint32_t value);
   public:
 
-  // uint32 njsT100 = 6;
-  void clear_njst100();
-  uint32_t njst100() const;
-  void set_njst100(uint32_t value);
+  // uint32 scrapeEndedUnix = 2;
+  void clear_scrapeendedunix();
+  uint32_t scrapeendedunix() const;
+  void set_scrapeendedunix(uint32_t value);
   private:
-  uint32_t _internal_njst100() const;
-  void _internal_set_njst100(uint32_t value);
+  uint32_t _internal_scrapeendedunix() const;
+  void _internal_set_scrapeendedunix(uint32_t value);
   public:
 
-  // uint32 bombs = 7;
-  void clear_bombs();
-  uint32_t bombs() const;
-  void set_bombs(uint32_t value);
-  private:
-  uint32_t _internal_bombs() const;
-  void _internal_set_bombs(uint32_t value);
-  public:
-
-  // uint32 notes = 8;
-  void clear_notes();
-  uint32_t notes() const;
-  void set_notes(uint32_t value);
-  private:
-  uint32_t _internal_notes() const;
-  void _internal_set_notes(uint32_t value);
-  public:
-
-  // uint32 obstacles = 9;
-  void clear_obstacles();
-  uint32_t obstacles() const;
-  void set_obstacles(uint32_t value);
-  private:
-  uint32_t _internal_obstacles() const;
-  void _internal_set_obstacles(uint32_t value);
-  public:
-
-  // optional uint32 mods = 10;
-  bool has_mods() const;
-  private:
-  bool _internal_has_mods() const;
-  public:
-  void clear_mods();
-  uint32_t mods() const;
-  void set_mods(uint32_t value);
-  private:
-  uint32_t _internal_mods() const;
-  void _internal_set_mods(uint32_t value);
-  public:
-
-  // @@protoc_insertion_point(class_scope:SongDetailsCache.Structs.SongDifficultyProto)
+  // @@protoc_insertion_point(class_scope:SongDetailsCache.Structs.SongDetailsV3)
  private:
   class _Internal;
 
@@ -299,41 +390,36 @@ class SongDifficultyProto final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongV3 > songs_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> taglist_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr songhashes_;
+    uint32_t formatversion_;
+    uint32_t scrapeendedunix_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
-    uint32_t characteristic_;
-    uint32_t difficulty_;
-    uint32_t starst100_;
-    uint32_t starst100bl_;
-    uint32_t njst100_;
-    uint32_t bombs_;
-    uint32_t notes_;
-    uint32_t obstacles_;
-    uint32_t mods_;
   };
   union { Impl_ _impl_; };
   friend struct ::TableStruct_SongProto_2eproto;
 };
 // -------------------------------------------------------------------
 
-class SongProto final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:SongDetailsCache.Structs.SongProto) */ {
+class SongV3 final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:SongDetailsCache.Structs.SongV3) */ {
  public:
-  inline SongProto() : SongProto(nullptr) {}
-  ~SongProto() override;
-  explicit PROTOBUF_CONSTEXPR SongProto(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline SongV3() : SongV3(nullptr) {}
+  ~SongV3() override;
+  explicit PROTOBUF_CONSTEXPR SongV3(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  SongProto(const SongProto& from);
-  SongProto(SongProto&& from) noexcept
-    : SongProto() {
+  SongV3(const SongV3& from);
+  SongV3(SongV3&& from) noexcept
+    : SongV3() {
     *this = ::std::move(from);
   }
 
-  inline SongProto& operator=(const SongProto& from) {
+  inline SongV3& operator=(const SongV3& from) {
     CopyFrom(from);
     return *this;
   }
-  inline SongProto& operator=(SongProto&& from) noexcept {
+  inline SongV3& operator=(SongV3&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()
   #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
@@ -356,20 +442,20 @@ class SongProto final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const SongProto& default_instance() {
+  static const SongV3& default_instance() {
     return *internal_default_instance();
   }
-  static inline const SongProto* internal_default_instance() {
-    return reinterpret_cast<const SongProto*>(
-               &_SongProto_default_instance_);
+  static inline const SongV3* internal_default_instance() {
+    return reinterpret_cast<const SongV3*>(
+               &_SongV3_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     1;
 
-  friend void swap(SongProto& a, SongProto& b) {
+  friend void swap(SongV3& a, SongV3& b) {
     a.Swap(&b);
   }
-  inline void Swap(SongProto* other) {
+  inline void Swap(SongV3* other) {
     if (other == this) return;
   #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
     if (GetOwningArena() != nullptr &&
@@ -382,7 +468,7 @@ class SongProto final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(SongProto* other) {
+  void UnsafeArenaSwap(SongV3* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -390,14 +476,14 @@ class SongProto final :
 
   // implements Message ----------------------------------------------
 
-  SongProto* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<SongProto>(arena);
+  SongV3* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<SongV3>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const SongProto& from);
+  void CopyFrom(const SongV3& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom( const SongProto& from) {
-    SongProto::MergeImpl(*this, from);
+  void MergeFrom( const SongV3& from) {
+    SongV3::MergeImpl(*this, from);
   }
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
@@ -415,15 +501,15 @@ class SongProto final :
   void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(SongProto* other);
+  void InternalSwap(SongV3* other);
 
   private:
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "SongDetailsCache.Structs.SongProto";
+    return "SongDetailsCache.Structs.SongV3";
   }
   protected:
-  explicit SongProto(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit SongV3(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   public:
 
@@ -437,56 +523,41 @@ class SongProto final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kDifficultiesFieldNumber = 13,
-    kHashBytesFieldNumber = 9,
-    kSongNameFieldNumber = 10,
-    kSongAuthorNameFieldNumber = 11,
-    kLevelAuthorNameFieldNumber = 12,
-    kUploaderNameFieldNumber = 16,
+    kDifficultiesFieldNumber = 11,
+    kSongNameFieldNumber = 7,
+    kSongAuthorNameFieldNumber = 8,
+    kLevelAuthorNameFieldNumber = 9,
+    kUploaderNameFieldNumber = 10,
     kBpmFieldNumber = 1,
-    kDownloadCountFieldNumber = 2,
-    kUpvotesFieldNumber = 3,
-    kDownvotesFieldNumber = 4,
-    kUploadTimeUnixFieldNumber = 5,
-    kMapIdFieldNumber = 6,
-    kSongDurationSecondsFieldNumber = 8,
-    kRankedChangeUnixFieldNumber = 14,
-    kRankedStateFieldNumber = 15,
-    kRankedStatesFieldNumber = 17,
+    kUpvotesFieldNumber = 2,
+    kDownvotesFieldNumber = 3,
+    kUploadTimeUnixFieldNumber = 4,
+    kMapIdFieldNumber = 5,
+    kSongDurationSecondsFieldNumber = 6,
+    kRankedChangeUnixFieldNumber = 12,
+    kRankedStateBitflagsFieldNumber = 13,
+    kTagsFieldNumber = 14,
+    kUploadFlagsFieldNumber = 15,
   };
-  // repeated .SongDetailsCache.Structs.SongDifficultyProto difficulties = 13;
+  // repeated .SongDetailsCache.Structs.SongDifficulty difficulties = 11;
   int difficulties_size() const;
   private:
   int _internal_difficulties_size() const;
   public:
   void clear_difficulties();
-  ::SongDetailsCache::Structs::SongDifficultyProto* mutable_difficulties(int index);
-  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficultyProto >*
+  ::SongDetailsCache::Structs::SongDifficulty* mutable_difficulties(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficulty >*
       mutable_difficulties();
   private:
-  const ::SongDetailsCache::Structs::SongDifficultyProto& _internal_difficulties(int index) const;
-  ::SongDetailsCache::Structs::SongDifficultyProto* _internal_add_difficulties();
+  const ::SongDetailsCache::Structs::SongDifficulty& _internal_difficulties(int index) const;
+  ::SongDetailsCache::Structs::SongDifficulty* _internal_add_difficulties();
   public:
-  const ::SongDetailsCache::Structs::SongDifficultyProto& difficulties(int index) const;
-  ::SongDetailsCache::Structs::SongDifficultyProto* add_difficulties();
-  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficultyProto >&
+  const ::SongDetailsCache::Structs::SongDifficulty& difficulties(int index) const;
+  ::SongDetailsCache::Structs::SongDifficulty* add_difficulties();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficulty >&
       difficulties() const;
 
-  // bytes hashBytes = 9;
-  void clear_hashbytes();
-  const std::string& hashbytes() const;
-  template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_hashbytes(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_hashbytes();
-  PROTOBUF_NODISCARD std::string* release_hashbytes();
-  void set_allocated_hashbytes(std::string* hashbytes);
-  private:
-  const std::string& _internal_hashbytes() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_hashbytes(const std::string& value);
-  std::string* _internal_mutable_hashbytes();
-  public:
-
-  // string songName = 10;
+  // string songName = 7;
   void clear_songname();
   const std::string& songname() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
@@ -500,7 +571,7 @@ class SongProto final :
   std::string* _internal_mutable_songname();
   public:
 
-  // string songAuthorName = 11;
+  // string songAuthorName = 8;
   void clear_songauthorname();
   const std::string& songauthorname() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
@@ -514,7 +585,7 @@ class SongProto final :
   std::string* _internal_mutable_songauthorname();
   public:
 
-  // string levelAuthorName = 12;
+  // string levelAuthorName = 9;
   void clear_levelauthorname();
   const std::string& levelauthorname() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
@@ -528,7 +599,11 @@ class SongProto final :
   std::string* _internal_mutable_levelauthorname();
   public:
 
-  // string uploaderName = 16;
+  // optional string uploaderName = 10;
+  bool has_uploadername() const;
+  private:
+  bool _internal_has_uploadername() const;
+  public:
   void clear_uploadername();
   const std::string& uploadername() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
@@ -551,16 +626,11 @@ class SongProto final :
   void _internal_set_bpm(float value);
   public:
 
-  // uint32 downloadCount = 2;
-  void clear_downloadcount();
-  uint32_t downloadcount() const;
-  void set_downloadcount(uint32_t value);
+  // optional uint32 upvotes = 2;
+  bool has_upvotes() const;
   private:
-  uint32_t _internal_downloadcount() const;
-  void _internal_set_downloadcount(uint32_t value);
+  bool _internal_has_upvotes() const;
   public:
-
-  // uint32 upvotes = 3;
   void clear_upvotes();
   uint32_t upvotes() const;
   void set_upvotes(uint32_t value);
@@ -569,7 +639,11 @@ class SongProto final :
   void _internal_set_upvotes(uint32_t value);
   public:
 
-  // uint32 downvotes = 4;
+  // optional uint32 downvotes = 3;
+  bool has_downvotes() const;
+  private:
+  bool _internal_has_downvotes() const;
+  public:
   void clear_downvotes();
   uint32_t downvotes() const;
   void set_downvotes(uint32_t value);
@@ -578,7 +652,7 @@ class SongProto final :
   void _internal_set_downvotes(uint32_t value);
   public:
 
-  // uint32 uploadTimeUnix = 5;
+  // uint32 uploadTimeUnix = 4;
   void clear_uploadtimeunix();
   uint32_t uploadtimeunix() const;
   void set_uploadtimeunix(uint32_t value);
@@ -587,7 +661,7 @@ class SongProto final :
   void _internal_set_uploadtimeunix(uint32_t value);
   public:
 
-  // uint32 mapId = 6;
+  // uint32 mapId = 5;
   void clear_mapid();
   uint32_t mapid() const;
   void set_mapid(uint32_t value);
@@ -596,7 +670,11 @@ class SongProto final :
   void _internal_set_mapid(uint32_t value);
   public:
 
-  // uint32 songDurationSeconds = 8;
+  // optional uint32 songDurationSeconds = 6;
+  bool has_songdurationseconds() const;
+  private:
+  bool _internal_has_songdurationseconds() const;
+  public:
   void clear_songdurationseconds();
   uint32_t songdurationseconds() const;
   void set_songdurationseconds(uint32_t value);
@@ -605,7 +683,11 @@ class SongProto final :
   void _internal_set_songdurationseconds(uint32_t value);
   public:
 
-  // uint32 rankedChangeUnix = 14;
+  // optional uint32 rankedChangeUnix = 12;
+  bool has_rankedchangeunix() const;
+  private:
+  bool _internal_has_rankedchangeunix() const;
+  public:
   void clear_rankedchangeunix();
   uint32_t rankedchangeunix() const;
   void set_rankedchangeunix(uint32_t value);
@@ -614,33 +696,46 @@ class SongProto final :
   void _internal_set_rankedchangeunix(uint32_t value);
   public:
 
-  // optional uint32 rankedState = 15;
-  bool has_rankedstate() const;
+  // optional .SongDetailsCache.Structs.RankedStatusBitflags rankedStateBitflags = 13;
+  bool has_rankedstatebitflags() const;
   private:
-  bool _internal_has_rankedstate() const;
+  bool _internal_has_rankedstatebitflags() const;
   public:
-  void clear_rankedstate();
-  uint32_t rankedstate() const;
-  void set_rankedstate(uint32_t value);
+  void clear_rankedstatebitflags();
+  ::SongDetailsCache::Structs::RankedStatusBitflags rankedstatebitflags() const;
+  void set_rankedstatebitflags(::SongDetailsCache::Structs::RankedStatusBitflags value);
   private:
-  uint32_t _internal_rankedstate() const;
-  void _internal_set_rankedstate(uint32_t value);
-  public:
-
-  // optional uint32 rankedStates = 17;
-  bool has_rankedstates() const;
-  private:
-  bool _internal_has_rankedstates() const;
-  public:
-  void clear_rankedstates();
-  uint32_t rankedstates() const;
-  void set_rankedstates(uint32_t value);
-  private:
-  uint32_t _internal_rankedstates() const;
-  void _internal_set_rankedstates(uint32_t value);
+  ::SongDetailsCache::Structs::RankedStatusBitflags _internal_rankedstatebitflags() const;
+  void _internal_set_rankedstatebitflags(::SongDetailsCache::Structs::RankedStatusBitflags value);
   public:
 
-  // @@protoc_insertion_point(class_scope:SongDetailsCache.Structs.SongProto)
+  // optional uint64 tags = 14;
+  bool has_tags() const;
+  private:
+  bool _internal_has_tags() const;
+  public:
+  void clear_tags();
+  uint64_t tags() const;
+  void set_tags(uint64_t value);
+  private:
+  uint64_t _internal_tags() const;
+  void _internal_set_tags(uint64_t value);
+  public:
+
+  // optional .SongDetailsCache.Structs.UploadFlags uploadFlags = 15;
+  bool has_uploadflags() const;
+  private:
+  bool _internal_has_uploadflags() const;
+  public:
+  void clear_uploadflags();
+  ::SongDetailsCache::Structs::UploadFlags uploadflags() const;
+  void set_uploadflags(::SongDetailsCache::Structs::UploadFlags value);
+  private:
+  ::SongDetailsCache::Structs::UploadFlags _internal_uploadflags() const;
+  void _internal_set_uploadflags(::SongDetailsCache::Structs::UploadFlags value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:SongDetailsCache.Structs.SongV3)
  private:
   class _Internal;
 
@@ -650,46 +745,45 @@ class SongProto final :
   struct Impl_ {
     ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
-    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficultyProto > difficulties_;
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr hashbytes_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficulty > difficulties_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr songname_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr songauthorname_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr levelauthorname_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr uploadername_;
     float bpm_;
-    uint32_t downloadcount_;
     uint32_t upvotes_;
     uint32_t downvotes_;
     uint32_t uploadtimeunix_;
     uint32_t mapid_;
     uint32_t songdurationseconds_;
     uint32_t rankedchangeunix_;
-    uint32_t rankedstate_;
-    uint32_t rankedstates_;
+    int rankedstatebitflags_;
+    uint64_t tags_;
+    int uploadflags_;
   };
   union { Impl_ _impl_; };
   friend struct ::TableStruct_SongProto_2eproto;
 };
 // -------------------------------------------------------------------
 
-class SongProtoContainer final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:SongDetailsCache.Structs.SongProtoContainer) */ {
+class SongDifficulty final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:SongDetailsCache.Structs.SongDifficulty) */ {
  public:
-  inline SongProtoContainer() : SongProtoContainer(nullptr) {}
-  ~SongProtoContainer() override;
-  explicit PROTOBUF_CONSTEXPR SongProtoContainer(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline SongDifficulty() : SongDifficulty(nullptr) {}
+  ~SongDifficulty() override;
+  explicit PROTOBUF_CONSTEXPR SongDifficulty(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  SongProtoContainer(const SongProtoContainer& from);
-  SongProtoContainer(SongProtoContainer&& from) noexcept
-    : SongProtoContainer() {
+  SongDifficulty(const SongDifficulty& from);
+  SongDifficulty(SongDifficulty&& from) noexcept
+    : SongDifficulty() {
     *this = ::std::move(from);
   }
 
-  inline SongProtoContainer& operator=(const SongProtoContainer& from) {
+  inline SongDifficulty& operator=(const SongDifficulty& from) {
     CopyFrom(from);
     return *this;
   }
-  inline SongProtoContainer& operator=(SongProtoContainer&& from) noexcept {
+  inline SongDifficulty& operator=(SongDifficulty&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()
   #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
@@ -712,20 +806,20 @@ class SongProtoContainer final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const SongProtoContainer& default_instance() {
+  static const SongDifficulty& default_instance() {
     return *internal_default_instance();
   }
-  static inline const SongProtoContainer* internal_default_instance() {
-    return reinterpret_cast<const SongProtoContainer*>(
-               &_SongProtoContainer_default_instance_);
+  static inline const SongDifficulty* internal_default_instance() {
+    return reinterpret_cast<const SongDifficulty*>(
+               &_SongDifficulty_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     2;
 
-  friend void swap(SongProtoContainer& a, SongProtoContainer& b) {
+  friend void swap(SongDifficulty& a, SongDifficulty& b) {
     a.Swap(&b);
   }
-  inline void Swap(SongProtoContainer* other) {
+  inline void Swap(SongDifficulty* other) {
     if (other == this) return;
   #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
     if (GetOwningArena() != nullptr &&
@@ -738,7 +832,7 @@ class SongProtoContainer final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(SongProtoContainer* other) {
+  void UnsafeArenaSwap(SongDifficulty* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -746,14 +840,14 @@ class SongProtoContainer final :
 
   // implements Message ----------------------------------------------
 
-  SongProtoContainer* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<SongProtoContainer>(arena);
+  SongDifficulty* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<SongDifficulty>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const SongProtoContainer& from);
+  void CopyFrom(const SongDifficulty& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom( const SongProtoContainer& from) {
-    SongProtoContainer::MergeImpl(*this, from);
+  void MergeFrom( const SongDifficulty& from) {
+    SongDifficulty::MergeImpl(*this, from);
   }
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
@@ -771,15 +865,15 @@ class SongProtoContainer final :
   void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(SongProtoContainer* other);
+  void InternalSwap(SongDifficulty* other);
 
   private:
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "SongDetailsCache.Structs.SongProtoContainer";
+    return "SongDetailsCache.Structs.SongDifficulty";
   }
   protected:
-  explicit SongProtoContainer(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit SongDifficulty(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   public:
 
@@ -790,50 +884,211 @@ class SongProtoContainer final :
 
   // nested types ----------------------------------------------------
 
+  typedef SongDifficulty_MapCharacteristic MapCharacteristic;
+  static constexpr MapCharacteristic Custom =
+    SongDifficulty_MapCharacteristic_Custom;
+  static constexpr MapCharacteristic Standard =
+    SongDifficulty_MapCharacteristic_Standard;
+  static constexpr MapCharacteristic OneSaber =
+    SongDifficulty_MapCharacteristic_OneSaber;
+  static constexpr MapCharacteristic NoArrows =
+    SongDifficulty_MapCharacteristic_NoArrows;
+  static constexpr MapCharacteristic NinetyDegree =
+    SongDifficulty_MapCharacteristic_NinetyDegree;
+  static constexpr MapCharacteristic ThreeSixtyDegree =
+    SongDifficulty_MapCharacteristic_ThreeSixtyDegree;
+  static constexpr MapCharacteristic Lightshow =
+    SongDifficulty_MapCharacteristic_Lightshow;
+  static constexpr MapCharacteristic Lawless =
+    SongDifficulty_MapCharacteristic_Lawless;
+  static inline bool MapCharacteristic_IsValid(int value) {
+    return SongDifficulty_MapCharacteristic_IsValid(value);
+  }
+  static constexpr MapCharacteristic MapCharacteristic_MIN =
+    SongDifficulty_MapCharacteristic_MapCharacteristic_MIN;
+  static constexpr MapCharacteristic MapCharacteristic_MAX =
+    SongDifficulty_MapCharacteristic_MapCharacteristic_MAX;
+  static constexpr int MapCharacteristic_ARRAYSIZE =
+    SongDifficulty_MapCharacteristic_MapCharacteristic_ARRAYSIZE;
+  static inline const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor*
+  MapCharacteristic_descriptor() {
+    return SongDifficulty_MapCharacteristic_descriptor();
+  }
+  template<typename T>
+  static inline const std::string& MapCharacteristic_Name(T enum_t_value) {
+    static_assert(::std::is_same<T, MapCharacteristic>::value ||
+      ::std::is_integral<T>::value,
+      "Incorrect type passed to function MapCharacteristic_Name.");
+    return SongDifficulty_MapCharacteristic_Name(enum_t_value);
+  }
+  static inline bool MapCharacteristic_Parse(::PROTOBUF_NAMESPACE_ID::ConstStringParam name,
+      MapCharacteristic* value) {
+    return SongDifficulty_MapCharacteristic_Parse(name, value);
+  }
+
+  typedef SongDifficulty_MapDifficulty MapDifficulty;
+  static constexpr MapDifficulty Easy =
+    SongDifficulty_MapDifficulty_Easy;
+  static constexpr MapDifficulty Normal =
+    SongDifficulty_MapDifficulty_Normal;
+  static constexpr MapDifficulty Hard =
+    SongDifficulty_MapDifficulty_Hard;
+  static constexpr MapDifficulty Expert =
+    SongDifficulty_MapDifficulty_Expert;
+  static constexpr MapDifficulty ExpertPlus =
+    SongDifficulty_MapDifficulty_ExpertPlus;
+  static inline bool MapDifficulty_IsValid(int value) {
+    return SongDifficulty_MapDifficulty_IsValid(value);
+  }
+  static constexpr MapDifficulty MapDifficulty_MIN =
+    SongDifficulty_MapDifficulty_MapDifficulty_MIN;
+  static constexpr MapDifficulty MapDifficulty_MAX =
+    SongDifficulty_MapDifficulty_MapDifficulty_MAX;
+  static constexpr int MapDifficulty_ARRAYSIZE =
+    SongDifficulty_MapDifficulty_MapDifficulty_ARRAYSIZE;
+  static inline const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor*
+  MapDifficulty_descriptor() {
+    return SongDifficulty_MapDifficulty_descriptor();
+  }
+  template<typename T>
+  static inline const std::string& MapDifficulty_Name(T enum_t_value) {
+    static_assert(::std::is_same<T, MapDifficulty>::value ||
+      ::std::is_integral<T>::value,
+      "Incorrect type passed to function MapDifficulty_Name.");
+    return SongDifficulty_MapDifficulty_Name(enum_t_value);
+  }
+  static inline bool MapDifficulty_Parse(::PROTOBUF_NAMESPACE_ID::ConstStringParam name,
+      MapDifficulty* value) {
+    return SongDifficulty_MapDifficulty_Parse(name, value);
+  }
+
   // accessors -------------------------------------------------------
 
   enum : int {
-    kSongsFieldNumber = 4,
-    kScrapeEndedTimeUnixFieldNumber = 2,
-    kFormatVersionFieldNumber = 1,
+    kCharacteristicFieldNumber = 1,
+    kDifficultyFieldNumber = 2,
+    kStarsT100FieldNumber = 4,
+    kStarsT100BLFieldNumber = 5,
+    kNjsT100FieldNumber = 6,
+    kBombsFieldNumber = 7,
+    kNotesFieldNumber = 8,
+    kObstaclesFieldNumber = 9,
+    kModsFieldNumber = 10,
   };
-  // repeated .SongDetailsCache.Structs.SongProto songs = 4;
-  int songs_size() const;
+  // optional .SongDetailsCache.Structs.SongDifficulty.MapCharacteristic characteristic = 1;
+  bool has_characteristic() const;
   private:
-  int _internal_songs_size() const;
+  bool _internal_has_characteristic() const;
   public:
-  void clear_songs();
-  ::SongDetailsCache::Structs::SongProto* mutable_songs(int index);
-  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongProto >*
-      mutable_songs();
+  void clear_characteristic();
+  ::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic characteristic() const;
+  void set_characteristic(::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic value);
   private:
-  const ::SongDetailsCache::Structs::SongProto& _internal_songs(int index) const;
-  ::SongDetailsCache::Structs::SongProto* _internal_add_songs();
-  public:
-  const ::SongDetailsCache::Structs::SongProto& songs(int index) const;
-  ::SongDetailsCache::Structs::SongProto* add_songs();
-  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongProto >&
-      songs() const;
-
-  // uint64 scrapeEndedTimeUnix = 2;
-  void clear_scrapeendedtimeunix();
-  uint64_t scrapeendedtimeunix() const;
-  void set_scrapeendedtimeunix(uint64_t value);
-  private:
-  uint64_t _internal_scrapeendedtimeunix() const;
-  void _internal_set_scrapeendedtimeunix(uint64_t value);
+  ::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic _internal_characteristic() const;
+  void _internal_set_characteristic(::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic value);
   public:
 
-  // uint32 formatVersion = 1;
-  void clear_formatversion();
-  uint32_t formatversion() const;
-  void set_formatversion(uint32_t value);
+  // optional .SongDetailsCache.Structs.SongDifficulty.MapDifficulty difficulty = 2;
+  bool has_difficulty() const;
   private:
-  uint32_t _internal_formatversion() const;
-  void _internal_set_formatversion(uint32_t value);
+  bool _internal_has_difficulty() const;
+  public:
+  void clear_difficulty();
+  ::SongDetailsCache::Structs::SongDifficulty_MapDifficulty difficulty() const;
+  void set_difficulty(::SongDetailsCache::Structs::SongDifficulty_MapDifficulty value);
+  private:
+  ::SongDetailsCache::Structs::SongDifficulty_MapDifficulty _internal_difficulty() const;
+  void _internal_set_difficulty(::SongDetailsCache::Structs::SongDifficulty_MapDifficulty value);
   public:
 
-  // @@protoc_insertion_point(class_scope:SongDetailsCache.Structs.SongProtoContainer)
+  // optional uint32 starsT100 = 4;
+  bool has_starst100() const;
+  private:
+  bool _internal_has_starst100() const;
+  public:
+  void clear_starst100();
+  uint32_t starst100() const;
+  void set_starst100(uint32_t value);
+  private:
+  uint32_t _internal_starst100() const;
+  void _internal_set_starst100(uint32_t value);
+  public:
+
+  // optional uint32 starsT100BL = 5;
+  bool has_starst100bl() const;
+  private:
+  bool _internal_has_starst100bl() const;
+  public:
+  void clear_starst100bl();
+  uint32_t starst100bl() const;
+  void set_starst100bl(uint32_t value);
+  private:
+  uint32_t _internal_starst100bl() const;
+  void _internal_set_starst100bl(uint32_t value);
+  public:
+
+  // uint32 njsT100 = 6;
+  void clear_njst100();
+  uint32_t njst100() const;
+  void set_njst100(uint32_t value);
+  private:
+  uint32_t _internal_njst100() const;
+  void _internal_set_njst100(uint32_t value);
+  public:
+
+  // optional uint32 bombs = 7;
+  bool has_bombs() const;
+  private:
+  bool _internal_has_bombs() const;
+  public:
+  void clear_bombs();
+  uint32_t bombs() const;
+  void set_bombs(uint32_t value);
+  private:
+  uint32_t _internal_bombs() const;
+  void _internal_set_bombs(uint32_t value);
+  public:
+
+  // optional uint32 notes = 8;
+  bool has_notes() const;
+  private:
+  bool _internal_has_notes() const;
+  public:
+  void clear_notes();
+  uint32_t notes() const;
+  void set_notes(uint32_t value);
+  private:
+  uint32_t _internal_notes() const;
+  void _internal_set_notes(uint32_t value);
+  public:
+
+  // optional uint32 obstacles = 9;
+  bool has_obstacles() const;
+  private:
+  bool _internal_has_obstacles() const;
+  public:
+  void clear_obstacles();
+  uint32_t obstacles() const;
+  void set_obstacles(uint32_t value);
+  private:
+  uint32_t _internal_obstacles() const;
+  void _internal_set_obstacles(uint32_t value);
+  public:
+
+  // optional uint32 mods = 10;
+  bool has_mods() const;
+  private:
+  bool _internal_has_mods() const;
+  public:
+  void clear_mods();
+  uint32_t mods() const;
+  void set_mods(uint32_t value);
+  private:
+  uint32_t _internal_mods() const;
+  void _internal_set_mods(uint32_t value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:SongDetailsCache.Structs.SongDifficulty)
  private:
   class _Internal;
 
@@ -841,10 +1096,17 @@ class SongProtoContainer final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongProto > songs_;
-    uint64_t scrapeendedtimeunix_;
-    uint32_t formatversion_;
+    ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    int characteristic_;
+    int difficulty_;
+    uint32_t starst100_;
+    uint32_t starst100bl_;
+    uint32_t njst100_;
+    uint32_t bombs_;
+    uint32_t notes_;
+    uint32_t obstacles_;
+    uint32_t mods_;
   };
   union { Impl_ _impl_; };
   friend struct ::TableStruct_SongProto_2eproto;
@@ -858,462 +1120,397 @@ class SongProtoContainer final :
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif  // __GNUC__
-// SongDifficultyProto
+// SongDetailsV3
 
-// optional uint32 characteristic = 1;
-inline bool SongDifficultyProto::_internal_has_characteristic() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
-  return value;
+// uint32 formatVersion = 1;
+inline void SongDetailsV3::clear_formatversion() {
+  _impl_.formatversion_ = 0u;
 }
-inline bool SongDifficultyProto::has_characteristic() const {
-  return _internal_has_characteristic();
+inline uint32_t SongDetailsV3::_internal_formatversion() const {
+  return _impl_.formatversion_;
 }
-inline void SongDifficultyProto::clear_characteristic() {
-  _impl_.characteristic_ = 0u;
-  _impl_._has_bits_[0] &= ~0x00000001u;
+inline uint32_t SongDetailsV3::formatversion() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDetailsV3.formatVersion)
+  return _internal_formatversion();
 }
-inline uint32_t SongDifficultyProto::_internal_characteristic() const {
-  return _impl_.characteristic_;
-}
-inline uint32_t SongDifficultyProto::characteristic() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.characteristic)
-  return _internal_characteristic();
-}
-inline void SongDifficultyProto::_internal_set_characteristic(uint32_t value) {
-  _impl_._has_bits_[0] |= 0x00000001u;
-  _impl_.characteristic_ = value;
-}
-inline void SongDifficultyProto::set_characteristic(uint32_t value) {
-  _internal_set_characteristic(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.characteristic)
-}
-
-// optional uint32 difficulty = 2;
-inline bool SongDifficultyProto::_internal_has_difficulty() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
-  return value;
-}
-inline bool SongDifficultyProto::has_difficulty() const {
-  return _internal_has_difficulty();
-}
-inline void SongDifficultyProto::clear_difficulty() {
-  _impl_.difficulty_ = 0u;
-  _impl_._has_bits_[0] &= ~0x00000002u;
-}
-inline uint32_t SongDifficultyProto::_internal_difficulty() const {
-  return _impl_.difficulty_;
-}
-inline uint32_t SongDifficultyProto::difficulty() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.difficulty)
-  return _internal_difficulty();
-}
-inline void SongDifficultyProto::_internal_set_difficulty(uint32_t value) {
-  _impl_._has_bits_[0] |= 0x00000002u;
-  _impl_.difficulty_ = value;
-}
-inline void SongDifficultyProto::set_difficulty(uint32_t value) {
-  _internal_set_difficulty(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.difficulty)
-}
-
-// uint32 starsT100 = 4;
-inline void SongDifficultyProto::clear_starst100() {
-  _impl_.starst100_ = 0u;
-}
-inline uint32_t SongDifficultyProto::_internal_starst100() const {
-  return _impl_.starst100_;
-}
-inline uint32_t SongDifficultyProto::starst100() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.starsT100)
-  return _internal_starst100();
-}
-inline void SongDifficultyProto::_internal_set_starst100(uint32_t value) {
+inline void SongDetailsV3::_internal_set_formatversion(uint32_t value) {
   
-  _impl_.starst100_ = value;
+  _impl_.formatversion_ = value;
 }
-inline void SongDifficultyProto::set_starst100(uint32_t value) {
-  _internal_set_starst100(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.starsT100)
+inline void SongDetailsV3::set_formatversion(uint32_t value) {
+  _internal_set_formatversion(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDetailsV3.formatVersion)
 }
 
-// uint32 starsT100BL = 5;
-inline void SongDifficultyProto::clear_starst100bl() {
-  _impl_.starst100bl_ = 0u;
+// uint32 scrapeEndedUnix = 2;
+inline void SongDetailsV3::clear_scrapeendedunix() {
+  _impl_.scrapeendedunix_ = 0u;
 }
-inline uint32_t SongDifficultyProto::_internal_starst100bl() const {
-  return _impl_.starst100bl_;
+inline uint32_t SongDetailsV3::_internal_scrapeendedunix() const {
+  return _impl_.scrapeendedunix_;
 }
-inline uint32_t SongDifficultyProto::starst100bl() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.starsT100BL)
-  return _internal_starst100bl();
+inline uint32_t SongDetailsV3::scrapeendedunix() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDetailsV3.scrapeEndedUnix)
+  return _internal_scrapeendedunix();
 }
-inline void SongDifficultyProto::_internal_set_starst100bl(uint32_t value) {
+inline void SongDetailsV3::_internal_set_scrapeendedunix(uint32_t value) {
   
-  _impl_.starst100bl_ = value;
+  _impl_.scrapeendedunix_ = value;
 }
-inline void SongDifficultyProto::set_starst100bl(uint32_t value) {
-  _internal_set_starst100bl(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.starsT100BL)
-}
-
-// uint32 njsT100 = 6;
-inline void SongDifficultyProto::clear_njst100() {
-  _impl_.njst100_ = 0u;
-}
-inline uint32_t SongDifficultyProto::_internal_njst100() const {
-  return _impl_.njst100_;
-}
-inline uint32_t SongDifficultyProto::njst100() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.njsT100)
-  return _internal_njst100();
-}
-inline void SongDifficultyProto::_internal_set_njst100(uint32_t value) {
-  
-  _impl_.njst100_ = value;
-}
-inline void SongDifficultyProto::set_njst100(uint32_t value) {
-  _internal_set_njst100(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.njsT100)
+inline void SongDetailsV3::set_scrapeendedunix(uint32_t value) {
+  _internal_set_scrapeendedunix(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDetailsV3.scrapeEndedUnix)
 }
 
-// uint32 bombs = 7;
-inline void SongDifficultyProto::clear_bombs() {
-  _impl_.bombs_ = 0u;
+// bytes songHashes = 3;
+inline void SongDetailsV3::clear_songhashes() {
+  _impl_.songhashes_.ClearToEmpty();
 }
-inline uint32_t SongDifficultyProto::_internal_bombs() const {
-  return _impl_.bombs_;
-}
-inline uint32_t SongDifficultyProto::bombs() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.bombs)
-  return _internal_bombs();
-}
-inline void SongDifficultyProto::_internal_set_bombs(uint32_t value) {
-  
-  _impl_.bombs_ = value;
-}
-inline void SongDifficultyProto::set_bombs(uint32_t value) {
-  _internal_set_bombs(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.bombs)
-}
-
-// uint32 notes = 8;
-inline void SongDifficultyProto::clear_notes() {
-  _impl_.notes_ = 0u;
-}
-inline uint32_t SongDifficultyProto::_internal_notes() const {
-  return _impl_.notes_;
-}
-inline uint32_t SongDifficultyProto::notes() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.notes)
-  return _internal_notes();
-}
-inline void SongDifficultyProto::_internal_set_notes(uint32_t value) {
-  
-  _impl_.notes_ = value;
-}
-inline void SongDifficultyProto::set_notes(uint32_t value) {
-  _internal_set_notes(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.notes)
-}
-
-// uint32 obstacles = 9;
-inline void SongDifficultyProto::clear_obstacles() {
-  _impl_.obstacles_ = 0u;
-}
-inline uint32_t SongDifficultyProto::_internal_obstacles() const {
-  return _impl_.obstacles_;
-}
-inline uint32_t SongDifficultyProto::obstacles() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.obstacles)
-  return _internal_obstacles();
-}
-inline void SongDifficultyProto::_internal_set_obstacles(uint32_t value) {
-  
-  _impl_.obstacles_ = value;
-}
-inline void SongDifficultyProto::set_obstacles(uint32_t value) {
-  _internal_set_obstacles(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.obstacles)
-}
-
-// optional uint32 mods = 10;
-inline bool SongDifficultyProto::_internal_has_mods() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000004u) != 0;
-  return value;
-}
-inline bool SongDifficultyProto::has_mods() const {
-  return _internal_has_mods();
-}
-inline void SongDifficultyProto::clear_mods() {
-  _impl_.mods_ = 0u;
-  _impl_._has_bits_[0] &= ~0x00000004u;
-}
-inline uint32_t SongDifficultyProto::_internal_mods() const {
-  return _impl_.mods_;
-}
-inline uint32_t SongDifficultyProto::mods() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficultyProto.mods)
-  return _internal_mods();
-}
-inline void SongDifficultyProto::_internal_set_mods(uint32_t value) {
-  _impl_._has_bits_[0] |= 0x00000004u;
-  _impl_.mods_ = value;
-}
-inline void SongDifficultyProto::set_mods(uint32_t value) {
-  _internal_set_mods(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficultyProto.mods)
-}
-
-// -------------------------------------------------------------------
-
-// SongProto
-
-// float bpm = 1;
-inline void SongProto::clear_bpm() {
-  _impl_.bpm_ = 0;
-}
-inline float SongProto::_internal_bpm() const {
-  return _impl_.bpm_;
-}
-inline float SongProto::bpm() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.bpm)
-  return _internal_bpm();
-}
-inline void SongProto::_internal_set_bpm(float value) {
-  
-  _impl_.bpm_ = value;
-}
-inline void SongProto::set_bpm(float value) {
-  _internal_set_bpm(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.bpm)
-}
-
-// uint32 downloadCount = 2;
-inline void SongProto::clear_downloadcount() {
-  _impl_.downloadcount_ = 0u;
-}
-inline uint32_t SongProto::_internal_downloadcount() const {
-  return _impl_.downloadcount_;
-}
-inline uint32_t SongProto::downloadcount() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.downloadCount)
-  return _internal_downloadcount();
-}
-inline void SongProto::_internal_set_downloadcount(uint32_t value) {
-  
-  _impl_.downloadcount_ = value;
-}
-inline void SongProto::set_downloadcount(uint32_t value) {
-  _internal_set_downloadcount(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.downloadCount)
-}
-
-// uint32 upvotes = 3;
-inline void SongProto::clear_upvotes() {
-  _impl_.upvotes_ = 0u;
-}
-inline uint32_t SongProto::_internal_upvotes() const {
-  return _impl_.upvotes_;
-}
-inline uint32_t SongProto::upvotes() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.upvotes)
-  return _internal_upvotes();
-}
-inline void SongProto::_internal_set_upvotes(uint32_t value) {
-  
-  _impl_.upvotes_ = value;
-}
-inline void SongProto::set_upvotes(uint32_t value) {
-  _internal_set_upvotes(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.upvotes)
-}
-
-// uint32 downvotes = 4;
-inline void SongProto::clear_downvotes() {
-  _impl_.downvotes_ = 0u;
-}
-inline uint32_t SongProto::_internal_downvotes() const {
-  return _impl_.downvotes_;
-}
-inline uint32_t SongProto::downvotes() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.downvotes)
-  return _internal_downvotes();
-}
-inline void SongProto::_internal_set_downvotes(uint32_t value) {
-  
-  _impl_.downvotes_ = value;
-}
-inline void SongProto::set_downvotes(uint32_t value) {
-  _internal_set_downvotes(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.downvotes)
-}
-
-// uint32 uploadTimeUnix = 5;
-inline void SongProto::clear_uploadtimeunix() {
-  _impl_.uploadtimeunix_ = 0u;
-}
-inline uint32_t SongProto::_internal_uploadtimeunix() const {
-  return _impl_.uploadtimeunix_;
-}
-inline uint32_t SongProto::uploadtimeunix() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.uploadTimeUnix)
-  return _internal_uploadtimeunix();
-}
-inline void SongProto::_internal_set_uploadtimeunix(uint32_t value) {
-  
-  _impl_.uploadtimeunix_ = value;
-}
-inline void SongProto::set_uploadtimeunix(uint32_t value) {
-  _internal_set_uploadtimeunix(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.uploadTimeUnix)
-}
-
-// uint32 rankedChangeUnix = 14;
-inline void SongProto::clear_rankedchangeunix() {
-  _impl_.rankedchangeunix_ = 0u;
-}
-inline uint32_t SongProto::_internal_rankedchangeunix() const {
-  return _impl_.rankedchangeunix_;
-}
-inline uint32_t SongProto::rankedchangeunix() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.rankedChangeUnix)
-  return _internal_rankedchangeunix();
-}
-inline void SongProto::_internal_set_rankedchangeunix(uint32_t value) {
-  
-  _impl_.rankedchangeunix_ = value;
-}
-inline void SongProto::set_rankedchangeunix(uint32_t value) {
-  _internal_set_rankedchangeunix(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.rankedChangeUnix)
-}
-
-// uint32 mapId = 6;
-inline void SongProto::clear_mapid() {
-  _impl_.mapid_ = 0u;
-}
-inline uint32_t SongProto::_internal_mapid() const {
-  return _impl_.mapid_;
-}
-inline uint32_t SongProto::mapid() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.mapId)
-  return _internal_mapid();
-}
-inline void SongProto::_internal_set_mapid(uint32_t value) {
-  
-  _impl_.mapid_ = value;
-}
-inline void SongProto::set_mapid(uint32_t value) {
-  _internal_set_mapid(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.mapId)
-}
-
-// uint32 songDurationSeconds = 8;
-inline void SongProto::clear_songdurationseconds() {
-  _impl_.songdurationseconds_ = 0u;
-}
-inline uint32_t SongProto::_internal_songdurationseconds() const {
-  return _impl_.songdurationseconds_;
-}
-inline uint32_t SongProto::songdurationseconds() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.songDurationSeconds)
-  return _internal_songdurationseconds();
-}
-inline void SongProto::_internal_set_songdurationseconds(uint32_t value) {
-  
-  _impl_.songdurationseconds_ = value;
-}
-inline void SongProto::set_songdurationseconds(uint32_t value) {
-  _internal_set_songdurationseconds(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.songDurationSeconds)
-}
-
-// bytes hashBytes = 9;
-inline void SongProto::clear_hashbytes() {
-  _impl_.hashbytes_.ClearToEmpty();
-}
-inline const std::string& SongProto::hashbytes() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.hashBytes)
-  return _internal_hashbytes();
+inline const std::string& SongDetailsV3::songhashes() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDetailsV3.songHashes)
+  return _internal_songhashes();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void SongProto::set_hashbytes(ArgT0&& arg0, ArgT... args) {
+void SongDetailsV3::set_songhashes(ArgT0&& arg0, ArgT... args) {
  
- _impl_.hashbytes_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.hashBytes)
+ _impl_.songhashes_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDetailsV3.songHashes)
 }
-inline std::string* SongProto::mutable_hashbytes() {
-  std::string* _s = _internal_mutable_hashbytes();
-  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongProto.hashBytes)
+inline std::string* SongDetailsV3::mutable_songhashes() {
+  std::string* _s = _internal_mutable_songhashes();
+  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongDetailsV3.songHashes)
   return _s;
 }
-inline const std::string& SongProto::_internal_hashbytes() const {
-  return _impl_.hashbytes_.Get();
+inline const std::string& SongDetailsV3::_internal_songhashes() const {
+  return _impl_.songhashes_.Get();
 }
-inline void SongProto::_internal_set_hashbytes(const std::string& value) {
+inline void SongDetailsV3::_internal_set_songhashes(const std::string& value) {
   
-  _impl_.hashbytes_.Set(value, GetArenaForAllocation());
+  _impl_.songhashes_.Set(value, GetArenaForAllocation());
 }
-inline std::string* SongProto::_internal_mutable_hashbytes() {
+inline std::string* SongDetailsV3::_internal_mutable_songhashes() {
   
-  return _impl_.hashbytes_.Mutable(GetArenaForAllocation());
+  return _impl_.songhashes_.Mutable(GetArenaForAllocation());
 }
-inline std::string* SongProto::release_hashbytes() {
-  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongProto.hashBytes)
-  return _impl_.hashbytes_.Release();
+inline std::string* SongDetailsV3::release_songhashes() {
+  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongDetailsV3.songHashes)
+  return _impl_.songhashes_.Release();
 }
-inline void SongProto::set_allocated_hashbytes(std::string* hashbytes) {
-  if (hashbytes != nullptr) {
+inline void SongDetailsV3::set_allocated_songhashes(std::string* songhashes) {
+  if (songhashes != nullptr) {
     
   } else {
     
   }
-  _impl_.hashbytes_.SetAllocated(hashbytes, GetArenaForAllocation());
+  _impl_.songhashes_.SetAllocated(songhashes, GetArenaForAllocation());
 #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.hashbytes_.IsDefault()) {
-    _impl_.hashbytes_.Set("", GetArenaForAllocation());
+  if (_impl_.songhashes_.IsDefault()) {
+    _impl_.songhashes_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongProto.hashBytes)
+  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongDetailsV3.songHashes)
 }
 
-// string songName = 10;
-inline void SongProto::clear_songname() {
+// repeated .SongDetailsCache.Structs.SongV3 songs = 4;
+inline int SongDetailsV3::_internal_songs_size() const {
+  return _impl_.songs_.size();
+}
+inline int SongDetailsV3::songs_size() const {
+  return _internal_songs_size();
+}
+inline void SongDetailsV3::clear_songs() {
+  _impl_.songs_.Clear();
+}
+inline ::SongDetailsCache::Structs::SongV3* SongDetailsV3::mutable_songs(int index) {
+  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongDetailsV3.songs)
+  return _impl_.songs_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongV3 >*
+SongDetailsV3::mutable_songs() {
+  // @@protoc_insertion_point(field_mutable_list:SongDetailsCache.Structs.SongDetailsV3.songs)
+  return &_impl_.songs_;
+}
+inline const ::SongDetailsCache::Structs::SongV3& SongDetailsV3::_internal_songs(int index) const {
+  return _impl_.songs_.Get(index);
+}
+inline const ::SongDetailsCache::Structs::SongV3& SongDetailsV3::songs(int index) const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDetailsV3.songs)
+  return _internal_songs(index);
+}
+inline ::SongDetailsCache::Structs::SongV3* SongDetailsV3::_internal_add_songs() {
+  return _impl_.songs_.Add();
+}
+inline ::SongDetailsCache::Structs::SongV3* SongDetailsV3::add_songs() {
+  ::SongDetailsCache::Structs::SongV3* _add = _internal_add_songs();
+  // @@protoc_insertion_point(field_add:SongDetailsCache.Structs.SongDetailsV3.songs)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongV3 >&
+SongDetailsV3::songs() const {
+  // @@protoc_insertion_point(field_list:SongDetailsCache.Structs.SongDetailsV3.songs)
+  return _impl_.songs_;
+}
+
+// repeated string tagList = 5;
+inline int SongDetailsV3::_internal_taglist_size() const {
+  return _impl_.taglist_.size();
+}
+inline int SongDetailsV3::taglist_size() const {
+  return _internal_taglist_size();
+}
+inline void SongDetailsV3::clear_taglist() {
+  _impl_.taglist_.Clear();
+}
+inline std::string* SongDetailsV3::add_taglist() {
+  std::string* _s = _internal_add_taglist();
+  // @@protoc_insertion_point(field_add_mutable:SongDetailsCache.Structs.SongDetailsV3.tagList)
+  return _s;
+}
+inline const std::string& SongDetailsV3::_internal_taglist(int index) const {
+  return _impl_.taglist_.Get(index);
+}
+inline const std::string& SongDetailsV3::taglist(int index) const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDetailsV3.tagList)
+  return _internal_taglist(index);
+}
+inline std::string* SongDetailsV3::mutable_taglist(int index) {
+  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongDetailsV3.tagList)
+  return _impl_.taglist_.Mutable(index);
+}
+inline void SongDetailsV3::set_taglist(int index, const std::string& value) {
+  _impl_.taglist_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDetailsV3.tagList)
+}
+inline void SongDetailsV3::set_taglist(int index, std::string&& value) {
+  _impl_.taglist_.Mutable(index)->assign(std::move(value));
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDetailsV3.tagList)
+}
+inline void SongDetailsV3::set_taglist(int index, const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  _impl_.taglist_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:SongDetailsCache.Structs.SongDetailsV3.tagList)
+}
+inline void SongDetailsV3::set_taglist(int index, const char* value, size_t size) {
+  _impl_.taglist_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:SongDetailsCache.Structs.SongDetailsV3.tagList)
+}
+inline std::string* SongDetailsV3::_internal_add_taglist() {
+  return _impl_.taglist_.Add();
+}
+inline void SongDetailsV3::add_taglist(const std::string& value) {
+  _impl_.taglist_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:SongDetailsCache.Structs.SongDetailsV3.tagList)
+}
+inline void SongDetailsV3::add_taglist(std::string&& value) {
+  _impl_.taglist_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:SongDetailsCache.Structs.SongDetailsV3.tagList)
+}
+inline void SongDetailsV3::add_taglist(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  _impl_.taglist_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:SongDetailsCache.Structs.SongDetailsV3.tagList)
+}
+inline void SongDetailsV3::add_taglist(const char* value, size_t size) {
+  _impl_.taglist_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:SongDetailsCache.Structs.SongDetailsV3.tagList)
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>&
+SongDetailsV3::taglist() const {
+  // @@protoc_insertion_point(field_list:SongDetailsCache.Structs.SongDetailsV3.tagList)
+  return _impl_.taglist_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>*
+SongDetailsV3::mutable_taglist() {
+  // @@protoc_insertion_point(field_mutable_list:SongDetailsCache.Structs.SongDetailsV3.tagList)
+  return &_impl_.taglist_;
+}
+
+// -------------------------------------------------------------------
+
+// SongV3
+
+// float bpm = 1;
+inline void SongV3::clear_bpm() {
+  _impl_.bpm_ = 0;
+}
+inline float SongV3::_internal_bpm() const {
+  return _impl_.bpm_;
+}
+inline float SongV3::bpm() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.bpm)
+  return _internal_bpm();
+}
+inline void SongV3::_internal_set_bpm(float value) {
+  
+  _impl_.bpm_ = value;
+}
+inline void SongV3::set_bpm(float value) {
+  _internal_set_bpm(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.bpm)
+}
+
+// optional uint32 upvotes = 2;
+inline bool SongV3::_internal_has_upvotes() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool SongV3::has_upvotes() const {
+  return _internal_has_upvotes();
+}
+inline void SongV3::clear_upvotes() {
+  _impl_.upvotes_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline uint32_t SongV3::_internal_upvotes() const {
+  return _impl_.upvotes_;
+}
+inline uint32_t SongV3::upvotes() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.upvotes)
+  return _internal_upvotes();
+}
+inline void SongV3::_internal_set_upvotes(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.upvotes_ = value;
+}
+inline void SongV3::set_upvotes(uint32_t value) {
+  _internal_set_upvotes(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.upvotes)
+}
+
+// optional uint32 downvotes = 3;
+inline bool SongV3::_internal_has_downvotes() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000004u) != 0;
+  return value;
+}
+inline bool SongV3::has_downvotes() const {
+  return _internal_has_downvotes();
+}
+inline void SongV3::clear_downvotes() {
+  _impl_.downvotes_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000004u;
+}
+inline uint32_t SongV3::_internal_downvotes() const {
+  return _impl_.downvotes_;
+}
+inline uint32_t SongV3::downvotes() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.downvotes)
+  return _internal_downvotes();
+}
+inline void SongV3::_internal_set_downvotes(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000004u;
+  _impl_.downvotes_ = value;
+}
+inline void SongV3::set_downvotes(uint32_t value) {
+  _internal_set_downvotes(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.downvotes)
+}
+
+// uint32 uploadTimeUnix = 4;
+inline void SongV3::clear_uploadtimeunix() {
+  _impl_.uploadtimeunix_ = 0u;
+}
+inline uint32_t SongV3::_internal_uploadtimeunix() const {
+  return _impl_.uploadtimeunix_;
+}
+inline uint32_t SongV3::uploadtimeunix() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.uploadTimeUnix)
+  return _internal_uploadtimeunix();
+}
+inline void SongV3::_internal_set_uploadtimeunix(uint32_t value) {
+  
+  _impl_.uploadtimeunix_ = value;
+}
+inline void SongV3::set_uploadtimeunix(uint32_t value) {
+  _internal_set_uploadtimeunix(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.uploadTimeUnix)
+}
+
+// uint32 mapId = 5;
+inline void SongV3::clear_mapid() {
+  _impl_.mapid_ = 0u;
+}
+inline uint32_t SongV3::_internal_mapid() const {
+  return _impl_.mapid_;
+}
+inline uint32_t SongV3::mapid() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.mapId)
+  return _internal_mapid();
+}
+inline void SongV3::_internal_set_mapid(uint32_t value) {
+  
+  _impl_.mapid_ = value;
+}
+inline void SongV3::set_mapid(uint32_t value) {
+  _internal_set_mapid(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.mapId)
+}
+
+// optional uint32 songDurationSeconds = 6;
+inline bool SongV3::_internal_has_songdurationseconds() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000008u) != 0;
+  return value;
+}
+inline bool SongV3::has_songdurationseconds() const {
+  return _internal_has_songdurationseconds();
+}
+inline void SongV3::clear_songdurationseconds() {
+  _impl_.songdurationseconds_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000008u;
+}
+inline uint32_t SongV3::_internal_songdurationseconds() const {
+  return _impl_.songdurationseconds_;
+}
+inline uint32_t SongV3::songdurationseconds() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.songDurationSeconds)
+  return _internal_songdurationseconds();
+}
+inline void SongV3::_internal_set_songdurationseconds(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000008u;
+  _impl_.songdurationseconds_ = value;
+}
+inline void SongV3::set_songdurationseconds(uint32_t value) {
+  _internal_set_songdurationseconds(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.songDurationSeconds)
+}
+
+// string songName = 7;
+inline void SongV3::clear_songname() {
   _impl_.songname_.ClearToEmpty();
 }
-inline const std::string& SongProto::songname() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.songName)
+inline const std::string& SongV3::songname() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.songName)
   return _internal_songname();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void SongProto::set_songname(ArgT0&& arg0, ArgT... args) {
+void SongV3::set_songname(ArgT0&& arg0, ArgT... args) {
  
  _impl_.songname_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.songName)
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.songName)
 }
-inline std::string* SongProto::mutable_songname() {
+inline std::string* SongV3::mutable_songname() {
   std::string* _s = _internal_mutable_songname();
-  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongProto.songName)
+  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongV3.songName)
   return _s;
 }
-inline const std::string& SongProto::_internal_songname() const {
+inline const std::string& SongV3::_internal_songname() const {
   return _impl_.songname_.Get();
 }
-inline void SongProto::_internal_set_songname(const std::string& value) {
+inline void SongV3::_internal_set_songname(const std::string& value) {
   
   _impl_.songname_.Set(value, GetArenaForAllocation());
 }
-inline std::string* SongProto::_internal_mutable_songname() {
+inline std::string* SongV3::_internal_mutable_songname() {
   
   return _impl_.songname_.Mutable(GetArenaForAllocation());
 }
-inline std::string* SongProto::release_songname() {
-  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongProto.songName)
+inline std::string* SongV3::release_songname() {
+  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongV3.songName)
   return _impl_.songname_.Release();
 }
-inline void SongProto::set_allocated_songname(std::string* songname) {
+inline void SongV3::set_allocated_songname(std::string* songname) {
   if (songname != nullptr) {
     
   } else {
@@ -1325,45 +1522,45 @@ inline void SongProto::set_allocated_songname(std::string* songname) {
     _impl_.songname_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongProto.songName)
+  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongV3.songName)
 }
 
-// string songAuthorName = 11;
-inline void SongProto::clear_songauthorname() {
+// string songAuthorName = 8;
+inline void SongV3::clear_songauthorname() {
   _impl_.songauthorname_.ClearToEmpty();
 }
-inline const std::string& SongProto::songauthorname() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.songAuthorName)
+inline const std::string& SongV3::songauthorname() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.songAuthorName)
   return _internal_songauthorname();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void SongProto::set_songauthorname(ArgT0&& arg0, ArgT... args) {
+void SongV3::set_songauthorname(ArgT0&& arg0, ArgT... args) {
  
  _impl_.songauthorname_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.songAuthorName)
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.songAuthorName)
 }
-inline std::string* SongProto::mutable_songauthorname() {
+inline std::string* SongV3::mutable_songauthorname() {
   std::string* _s = _internal_mutable_songauthorname();
-  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongProto.songAuthorName)
+  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongV3.songAuthorName)
   return _s;
 }
-inline const std::string& SongProto::_internal_songauthorname() const {
+inline const std::string& SongV3::_internal_songauthorname() const {
   return _impl_.songauthorname_.Get();
 }
-inline void SongProto::_internal_set_songauthorname(const std::string& value) {
+inline void SongV3::_internal_set_songauthorname(const std::string& value) {
   
   _impl_.songauthorname_.Set(value, GetArenaForAllocation());
 }
-inline std::string* SongProto::_internal_mutable_songauthorname() {
+inline std::string* SongV3::_internal_mutable_songauthorname() {
   
   return _impl_.songauthorname_.Mutable(GetArenaForAllocation());
 }
-inline std::string* SongProto::release_songauthorname() {
-  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongProto.songAuthorName)
+inline std::string* SongV3::release_songauthorname() {
+  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongV3.songAuthorName)
   return _impl_.songauthorname_.Release();
 }
-inline void SongProto::set_allocated_songauthorname(std::string* songauthorname) {
+inline void SongV3::set_allocated_songauthorname(std::string* songauthorname) {
   if (songauthorname != nullptr) {
     
   } else {
@@ -1375,45 +1572,45 @@ inline void SongProto::set_allocated_songauthorname(std::string* songauthorname)
     _impl_.songauthorname_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongProto.songAuthorName)
+  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongV3.songAuthorName)
 }
 
-// string levelAuthorName = 12;
-inline void SongProto::clear_levelauthorname() {
+// string levelAuthorName = 9;
+inline void SongV3::clear_levelauthorname() {
   _impl_.levelauthorname_.ClearToEmpty();
 }
-inline const std::string& SongProto::levelauthorname() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.levelAuthorName)
+inline const std::string& SongV3::levelauthorname() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.levelAuthorName)
   return _internal_levelauthorname();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void SongProto::set_levelauthorname(ArgT0&& arg0, ArgT... args) {
+void SongV3::set_levelauthorname(ArgT0&& arg0, ArgT... args) {
  
  _impl_.levelauthorname_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.levelAuthorName)
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.levelAuthorName)
 }
-inline std::string* SongProto::mutable_levelauthorname() {
+inline std::string* SongV3::mutable_levelauthorname() {
   std::string* _s = _internal_mutable_levelauthorname();
-  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongProto.levelAuthorName)
+  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongV3.levelAuthorName)
   return _s;
 }
-inline const std::string& SongProto::_internal_levelauthorname() const {
+inline const std::string& SongV3::_internal_levelauthorname() const {
   return _impl_.levelauthorname_.Get();
 }
-inline void SongProto::_internal_set_levelauthorname(const std::string& value) {
+inline void SongV3::_internal_set_levelauthorname(const std::string& value) {
   
   _impl_.levelauthorname_.Set(value, GetArenaForAllocation());
 }
-inline std::string* SongProto::_internal_mutable_levelauthorname() {
+inline std::string* SongV3::_internal_mutable_levelauthorname() {
   
   return _impl_.levelauthorname_.Mutable(GetArenaForAllocation());
 }
-inline std::string* SongProto::release_levelauthorname() {
-  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongProto.levelAuthorName)
+inline std::string* SongV3::release_levelauthorname() {
+  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongV3.levelAuthorName)
   return _impl_.levelauthorname_.Release();
 }
-inline void SongProto::set_allocated_levelauthorname(std::string* levelauthorname) {
+inline void SongV3::set_allocated_levelauthorname(std::string* levelauthorname) {
   if (levelauthorname != nullptr) {
     
   } else {
@@ -1425,117 +1622,67 @@ inline void SongProto::set_allocated_levelauthorname(std::string* levelauthornam
     _impl_.levelauthorname_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongProto.levelAuthorName)
+  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongV3.levelAuthorName)
 }
 
-// optional uint32 rankedState = 15;
-inline bool SongProto::_internal_has_rankedstate() const {
+// optional string uploaderName = 10;
+inline bool SongV3::_internal_has_uploadername() const {
   bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
   return value;
 }
-inline bool SongProto::has_rankedstate() const {
-  return _internal_has_rankedstate();
+inline bool SongV3::has_uploadername() const {
+  return _internal_has_uploadername();
 }
-inline void SongProto::clear_rankedstate() {
-  _impl_.rankedstate_ = 0u;
+inline void SongV3::clear_uploadername() {
+  _impl_.uploadername_.ClearToEmpty();
   _impl_._has_bits_[0] &= ~0x00000001u;
 }
-inline uint32_t SongProto::_internal_rankedstate() const {
-  return _impl_.rankedstate_;
-}
-inline uint32_t SongProto::rankedstate() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.rankedState)
-  return _internal_rankedstate();
-}
-inline void SongProto::_internal_set_rankedstate(uint32_t value) {
-  _impl_._has_bits_[0] |= 0x00000001u;
-  _impl_.rankedstate_ = value;
-}
-inline void SongProto::set_rankedstate(uint32_t value) {
-  _internal_set_rankedstate(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.rankedState)
-}
-
-// repeated .SongDetailsCache.Structs.SongDifficultyProto difficulties = 13;
-inline int SongProto::_internal_difficulties_size() const {
-  return _impl_.difficulties_.size();
-}
-inline int SongProto::difficulties_size() const {
-  return _internal_difficulties_size();
-}
-inline void SongProto::clear_difficulties() {
-  _impl_.difficulties_.Clear();
-}
-inline ::SongDetailsCache::Structs::SongDifficultyProto* SongProto::mutable_difficulties(int index) {
-  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongProto.difficulties)
-  return _impl_.difficulties_.Mutable(index);
-}
-inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficultyProto >*
-SongProto::mutable_difficulties() {
-  // @@protoc_insertion_point(field_mutable_list:SongDetailsCache.Structs.SongProto.difficulties)
-  return &_impl_.difficulties_;
-}
-inline const ::SongDetailsCache::Structs::SongDifficultyProto& SongProto::_internal_difficulties(int index) const {
-  return _impl_.difficulties_.Get(index);
-}
-inline const ::SongDetailsCache::Structs::SongDifficultyProto& SongProto::difficulties(int index) const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.difficulties)
-  return _internal_difficulties(index);
-}
-inline ::SongDetailsCache::Structs::SongDifficultyProto* SongProto::_internal_add_difficulties() {
-  return _impl_.difficulties_.Add();
-}
-inline ::SongDetailsCache::Structs::SongDifficultyProto* SongProto::add_difficulties() {
-  ::SongDetailsCache::Structs::SongDifficultyProto* _add = _internal_add_difficulties();
-  // @@protoc_insertion_point(field_add:SongDetailsCache.Structs.SongProto.difficulties)
-  return _add;
-}
-inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficultyProto >&
-SongProto::difficulties() const {
-  // @@protoc_insertion_point(field_list:SongDetailsCache.Structs.SongProto.difficulties)
-  return _impl_.difficulties_;
-}
-
-// string uploaderName = 16;
-inline void SongProto::clear_uploadername() {
-  _impl_.uploadername_.ClearToEmpty();
-}
-inline const std::string& SongProto::uploadername() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.uploaderName)
+inline const std::string& SongV3::uploadername() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.uploaderName)
   return _internal_uploadername();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void SongProto::set_uploadername(ArgT0&& arg0, ArgT... args) {
- 
+void SongV3::set_uploadername(ArgT0&& arg0, ArgT... args) {
+ _impl_._has_bits_[0] |= 0x00000001u;
  _impl_.uploadername_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.uploaderName)
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.uploaderName)
 }
-inline std::string* SongProto::mutable_uploadername() {
+inline std::string* SongV3::mutable_uploadername() {
   std::string* _s = _internal_mutable_uploadername();
-  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongProto.uploaderName)
+  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongV3.uploaderName)
   return _s;
 }
-inline const std::string& SongProto::_internal_uploadername() const {
+inline const std::string& SongV3::_internal_uploadername() const {
   return _impl_.uploadername_.Get();
 }
-inline void SongProto::_internal_set_uploadername(const std::string& value) {
-  
+inline void SongV3::_internal_set_uploadername(const std::string& value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
   _impl_.uploadername_.Set(value, GetArenaForAllocation());
 }
-inline std::string* SongProto::_internal_mutable_uploadername() {
-  
+inline std::string* SongV3::_internal_mutable_uploadername() {
+  _impl_._has_bits_[0] |= 0x00000001u;
   return _impl_.uploadername_.Mutable(GetArenaForAllocation());
 }
-inline std::string* SongProto::release_uploadername() {
-  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongProto.uploaderName)
-  return _impl_.uploadername_.Release();
+inline std::string* SongV3::release_uploadername() {
+  // @@protoc_insertion_point(field_release:SongDetailsCache.Structs.SongV3.uploaderName)
+  if (!_internal_has_uploadername()) {
+    return nullptr;
+  }
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  auto* p = _impl_.uploadername_.Release();
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.uploadername_.IsDefault()) {
+    _impl_.uploadername_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  return p;
 }
-inline void SongProto::set_allocated_uploadername(std::string* uploadername) {
+inline void SongV3::set_allocated_uploadername(std::string* uploadername) {
   if (uploadername != nullptr) {
-    
+    _impl_._has_bits_[0] |= 0x00000001u;
   } else {
-    
+    _impl_._has_bits_[0] &= ~0x00000001u;
   }
   _impl_.uploadername_.SetAllocated(uploadername, GetArenaForAllocation());
 #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
@@ -1543,119 +1690,407 @@ inline void SongProto::set_allocated_uploadername(std::string* uploadername) {
     _impl_.uploadername_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongProto.uploaderName)
+  // @@protoc_insertion_point(field_set_allocated:SongDetailsCache.Structs.SongV3.uploaderName)
 }
 
-// optional uint32 rankedStates = 17;
-inline bool SongProto::_internal_has_rankedstates() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+// repeated .SongDetailsCache.Structs.SongDifficulty difficulties = 11;
+inline int SongV3::_internal_difficulties_size() const {
+  return _impl_.difficulties_.size();
+}
+inline int SongV3::difficulties_size() const {
+  return _internal_difficulties_size();
+}
+inline void SongV3::clear_difficulties() {
+  _impl_.difficulties_.Clear();
+}
+inline ::SongDetailsCache::Structs::SongDifficulty* SongV3::mutable_difficulties(int index) {
+  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongV3.difficulties)
+  return _impl_.difficulties_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficulty >*
+SongV3::mutable_difficulties() {
+  // @@protoc_insertion_point(field_mutable_list:SongDetailsCache.Structs.SongV3.difficulties)
+  return &_impl_.difficulties_;
+}
+inline const ::SongDetailsCache::Structs::SongDifficulty& SongV3::_internal_difficulties(int index) const {
+  return _impl_.difficulties_.Get(index);
+}
+inline const ::SongDetailsCache::Structs::SongDifficulty& SongV3::difficulties(int index) const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.difficulties)
+  return _internal_difficulties(index);
+}
+inline ::SongDetailsCache::Structs::SongDifficulty* SongV3::_internal_add_difficulties() {
+  return _impl_.difficulties_.Add();
+}
+inline ::SongDetailsCache::Structs::SongDifficulty* SongV3::add_difficulties() {
+  ::SongDetailsCache::Structs::SongDifficulty* _add = _internal_add_difficulties();
+  // @@protoc_insertion_point(field_add:SongDetailsCache.Structs.SongV3.difficulties)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongDifficulty >&
+SongV3::difficulties() const {
+  // @@protoc_insertion_point(field_list:SongDetailsCache.Structs.SongV3.difficulties)
+  return _impl_.difficulties_;
+}
+
+// optional uint32 rankedChangeUnix = 12;
+inline bool SongV3::_internal_has_rankedchangeunix() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000010u) != 0;
   return value;
 }
-inline bool SongProto::has_rankedstates() const {
-  return _internal_has_rankedstates();
+inline bool SongV3::has_rankedchangeunix() const {
+  return _internal_has_rankedchangeunix();
 }
-inline void SongProto::clear_rankedstates() {
-  _impl_.rankedstates_ = 0u;
-  _impl_._has_bits_[0] &= ~0x00000002u;
+inline void SongV3::clear_rankedchangeunix() {
+  _impl_.rankedchangeunix_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000010u;
 }
-inline uint32_t SongProto::_internal_rankedstates() const {
-  return _impl_.rankedstates_;
+inline uint32_t SongV3::_internal_rankedchangeunix() const {
+  return _impl_.rankedchangeunix_;
 }
-inline uint32_t SongProto::rankedstates() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProto.rankedStates)
-  return _internal_rankedstates();
+inline uint32_t SongV3::rankedchangeunix() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.rankedChangeUnix)
+  return _internal_rankedchangeunix();
 }
-inline void SongProto::_internal_set_rankedstates(uint32_t value) {
-  _impl_._has_bits_[0] |= 0x00000002u;
-  _impl_.rankedstates_ = value;
+inline void SongV3::_internal_set_rankedchangeunix(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000010u;
+  _impl_.rankedchangeunix_ = value;
 }
-inline void SongProto::set_rankedstates(uint32_t value) {
-  _internal_set_rankedstates(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProto.rankedStates)
+inline void SongV3::set_rankedchangeunix(uint32_t value) {
+  _internal_set_rankedchangeunix(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.rankedChangeUnix)
+}
+
+// optional .SongDetailsCache.Structs.RankedStatusBitflags rankedStateBitflags = 13;
+inline bool SongV3::_internal_has_rankedstatebitflags() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000020u) != 0;
+  return value;
+}
+inline bool SongV3::has_rankedstatebitflags() const {
+  return _internal_has_rankedstatebitflags();
+}
+inline void SongV3::clear_rankedstatebitflags() {
+  _impl_.rankedstatebitflags_ = 0;
+  _impl_._has_bits_[0] &= ~0x00000020u;
+}
+inline ::SongDetailsCache::Structs::RankedStatusBitflags SongV3::_internal_rankedstatebitflags() const {
+  return static_cast< ::SongDetailsCache::Structs::RankedStatusBitflags >(_impl_.rankedstatebitflags_);
+}
+inline ::SongDetailsCache::Structs::RankedStatusBitflags SongV3::rankedstatebitflags() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.rankedStateBitflags)
+  return _internal_rankedstatebitflags();
+}
+inline void SongV3::_internal_set_rankedstatebitflags(::SongDetailsCache::Structs::RankedStatusBitflags value) {
+  _impl_._has_bits_[0] |= 0x00000020u;
+  _impl_.rankedstatebitflags_ = value;
+}
+inline void SongV3::set_rankedstatebitflags(::SongDetailsCache::Structs::RankedStatusBitflags value) {
+  _internal_set_rankedstatebitflags(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.rankedStateBitflags)
+}
+
+// optional uint64 tags = 14;
+inline bool SongV3::_internal_has_tags() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000040u) != 0;
+  return value;
+}
+inline bool SongV3::has_tags() const {
+  return _internal_has_tags();
+}
+inline void SongV3::clear_tags() {
+  _impl_.tags_ = uint64_t{0u};
+  _impl_._has_bits_[0] &= ~0x00000040u;
+}
+inline uint64_t SongV3::_internal_tags() const {
+  return _impl_.tags_;
+}
+inline uint64_t SongV3::tags() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.tags)
+  return _internal_tags();
+}
+inline void SongV3::_internal_set_tags(uint64_t value) {
+  _impl_._has_bits_[0] |= 0x00000040u;
+  _impl_.tags_ = value;
+}
+inline void SongV3::set_tags(uint64_t value) {
+  _internal_set_tags(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.tags)
+}
+
+// optional .SongDetailsCache.Structs.UploadFlags uploadFlags = 15;
+inline bool SongV3::_internal_has_uploadflags() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000080u) != 0;
+  return value;
+}
+inline bool SongV3::has_uploadflags() const {
+  return _internal_has_uploadflags();
+}
+inline void SongV3::clear_uploadflags() {
+  _impl_.uploadflags_ = 0;
+  _impl_._has_bits_[0] &= ~0x00000080u;
+}
+inline ::SongDetailsCache::Structs::UploadFlags SongV3::_internal_uploadflags() const {
+  return static_cast< ::SongDetailsCache::Structs::UploadFlags >(_impl_.uploadflags_);
+}
+inline ::SongDetailsCache::Structs::UploadFlags SongV3::uploadflags() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongV3.uploadFlags)
+  return _internal_uploadflags();
+}
+inline void SongV3::_internal_set_uploadflags(::SongDetailsCache::Structs::UploadFlags value) {
+  _impl_._has_bits_[0] |= 0x00000080u;
+  _impl_.uploadflags_ = value;
+}
+inline void SongV3::set_uploadflags(::SongDetailsCache::Structs::UploadFlags value) {
+  _internal_set_uploadflags(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongV3.uploadFlags)
 }
 
 // -------------------------------------------------------------------
 
-// SongProtoContainer
+// SongDifficulty
 
-// uint32 formatVersion = 1;
-inline void SongProtoContainer::clear_formatversion() {
-  _impl_.formatversion_ = 0u;
+// optional .SongDetailsCache.Structs.SongDifficulty.MapCharacteristic characteristic = 1;
+inline bool SongDifficulty::_internal_has_characteristic() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  return value;
 }
-inline uint32_t SongProtoContainer::_internal_formatversion() const {
-  return _impl_.formatversion_;
+inline bool SongDifficulty::has_characteristic() const {
+  return _internal_has_characteristic();
 }
-inline uint32_t SongProtoContainer::formatversion() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProtoContainer.formatVersion)
-  return _internal_formatversion();
+inline void SongDifficulty::clear_characteristic() {
+  _impl_.characteristic_ = 0;
+  _impl_._has_bits_[0] &= ~0x00000001u;
 }
-inline void SongProtoContainer::_internal_set_formatversion(uint32_t value) {
+inline ::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic SongDifficulty::_internal_characteristic() const {
+  return static_cast< ::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic >(_impl_.characteristic_);
+}
+inline ::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic SongDifficulty::characteristic() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.characteristic)
+  return _internal_characteristic();
+}
+inline void SongDifficulty::_internal_set_characteristic(::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic value) {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  _impl_.characteristic_ = value;
+}
+inline void SongDifficulty::set_characteristic(::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic value) {
+  _internal_set_characteristic(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.characteristic)
+}
+
+// optional .SongDetailsCache.Structs.SongDifficulty.MapDifficulty difficulty = 2;
+inline bool SongDifficulty::_internal_has_difficulty() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000002u) != 0;
+  return value;
+}
+inline bool SongDifficulty::has_difficulty() const {
+  return _internal_has_difficulty();
+}
+inline void SongDifficulty::clear_difficulty() {
+  _impl_.difficulty_ = 0;
+  _impl_._has_bits_[0] &= ~0x00000002u;
+}
+inline ::SongDetailsCache::Structs::SongDifficulty_MapDifficulty SongDifficulty::_internal_difficulty() const {
+  return static_cast< ::SongDetailsCache::Structs::SongDifficulty_MapDifficulty >(_impl_.difficulty_);
+}
+inline ::SongDetailsCache::Structs::SongDifficulty_MapDifficulty SongDifficulty::difficulty() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.difficulty)
+  return _internal_difficulty();
+}
+inline void SongDifficulty::_internal_set_difficulty(::SongDetailsCache::Structs::SongDifficulty_MapDifficulty value) {
+  _impl_._has_bits_[0] |= 0x00000002u;
+  _impl_.difficulty_ = value;
+}
+inline void SongDifficulty::set_difficulty(::SongDetailsCache::Structs::SongDifficulty_MapDifficulty value) {
+  _internal_set_difficulty(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.difficulty)
+}
+
+// optional uint32 starsT100 = 4;
+inline bool SongDifficulty::_internal_has_starst100() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000004u) != 0;
+  return value;
+}
+inline bool SongDifficulty::has_starst100() const {
+  return _internal_has_starst100();
+}
+inline void SongDifficulty::clear_starst100() {
+  _impl_.starst100_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000004u;
+}
+inline uint32_t SongDifficulty::_internal_starst100() const {
+  return _impl_.starst100_;
+}
+inline uint32_t SongDifficulty::starst100() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.starsT100)
+  return _internal_starst100();
+}
+inline void SongDifficulty::_internal_set_starst100(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000004u;
+  _impl_.starst100_ = value;
+}
+inline void SongDifficulty::set_starst100(uint32_t value) {
+  _internal_set_starst100(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.starsT100)
+}
+
+// optional uint32 starsT100BL = 5;
+inline bool SongDifficulty::_internal_has_starst100bl() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000008u) != 0;
+  return value;
+}
+inline bool SongDifficulty::has_starst100bl() const {
+  return _internal_has_starst100bl();
+}
+inline void SongDifficulty::clear_starst100bl() {
+  _impl_.starst100bl_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000008u;
+}
+inline uint32_t SongDifficulty::_internal_starst100bl() const {
+  return _impl_.starst100bl_;
+}
+inline uint32_t SongDifficulty::starst100bl() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.starsT100BL)
+  return _internal_starst100bl();
+}
+inline void SongDifficulty::_internal_set_starst100bl(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000008u;
+  _impl_.starst100bl_ = value;
+}
+inline void SongDifficulty::set_starst100bl(uint32_t value) {
+  _internal_set_starst100bl(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.starsT100BL)
+}
+
+// uint32 njsT100 = 6;
+inline void SongDifficulty::clear_njst100() {
+  _impl_.njst100_ = 0u;
+}
+inline uint32_t SongDifficulty::_internal_njst100() const {
+  return _impl_.njst100_;
+}
+inline uint32_t SongDifficulty::njst100() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.njsT100)
+  return _internal_njst100();
+}
+inline void SongDifficulty::_internal_set_njst100(uint32_t value) {
   
-  _impl_.formatversion_ = value;
+  _impl_.njst100_ = value;
 }
-inline void SongProtoContainer::set_formatversion(uint32_t value) {
-  _internal_set_formatversion(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProtoContainer.formatVersion)
-}
-
-// uint64 scrapeEndedTimeUnix = 2;
-inline void SongProtoContainer::clear_scrapeendedtimeunix() {
-  _impl_.scrapeendedtimeunix_ = uint64_t{0u};
-}
-inline uint64_t SongProtoContainer::_internal_scrapeendedtimeunix() const {
-  return _impl_.scrapeendedtimeunix_;
-}
-inline uint64_t SongProtoContainer::scrapeendedtimeunix() const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProtoContainer.scrapeEndedTimeUnix)
-  return _internal_scrapeendedtimeunix();
-}
-inline void SongProtoContainer::_internal_set_scrapeendedtimeunix(uint64_t value) {
-  
-  _impl_.scrapeendedtimeunix_ = value;
-}
-inline void SongProtoContainer::set_scrapeendedtimeunix(uint64_t value) {
-  _internal_set_scrapeendedtimeunix(value);
-  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongProtoContainer.scrapeEndedTimeUnix)
+inline void SongDifficulty::set_njst100(uint32_t value) {
+  _internal_set_njst100(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.njsT100)
 }
 
-// repeated .SongDetailsCache.Structs.SongProto songs = 4;
-inline int SongProtoContainer::_internal_songs_size() const {
-  return _impl_.songs_.size();
+// optional uint32 bombs = 7;
+inline bool SongDifficulty::_internal_has_bombs() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000010u) != 0;
+  return value;
 }
-inline int SongProtoContainer::songs_size() const {
-  return _internal_songs_size();
+inline bool SongDifficulty::has_bombs() const {
+  return _internal_has_bombs();
 }
-inline void SongProtoContainer::clear_songs() {
-  _impl_.songs_.Clear();
+inline void SongDifficulty::clear_bombs() {
+  _impl_.bombs_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000010u;
 }
-inline ::SongDetailsCache::Structs::SongProto* SongProtoContainer::mutable_songs(int index) {
-  // @@protoc_insertion_point(field_mutable:SongDetailsCache.Structs.SongProtoContainer.songs)
-  return _impl_.songs_.Mutable(index);
+inline uint32_t SongDifficulty::_internal_bombs() const {
+  return _impl_.bombs_;
 }
-inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongProto >*
-SongProtoContainer::mutable_songs() {
-  // @@protoc_insertion_point(field_mutable_list:SongDetailsCache.Structs.SongProtoContainer.songs)
-  return &_impl_.songs_;
+inline uint32_t SongDifficulty::bombs() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.bombs)
+  return _internal_bombs();
 }
-inline const ::SongDetailsCache::Structs::SongProto& SongProtoContainer::_internal_songs(int index) const {
-  return _impl_.songs_.Get(index);
+inline void SongDifficulty::_internal_set_bombs(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000010u;
+  _impl_.bombs_ = value;
 }
-inline const ::SongDetailsCache::Structs::SongProto& SongProtoContainer::songs(int index) const {
-  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongProtoContainer.songs)
-  return _internal_songs(index);
+inline void SongDifficulty::set_bombs(uint32_t value) {
+  _internal_set_bombs(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.bombs)
 }
-inline ::SongDetailsCache::Structs::SongProto* SongProtoContainer::_internal_add_songs() {
-  return _impl_.songs_.Add();
+
+// optional uint32 notes = 8;
+inline bool SongDifficulty::_internal_has_notes() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000020u) != 0;
+  return value;
 }
-inline ::SongDetailsCache::Structs::SongProto* SongProtoContainer::add_songs() {
-  ::SongDetailsCache::Structs::SongProto* _add = _internal_add_songs();
-  // @@protoc_insertion_point(field_add:SongDetailsCache.Structs.SongProtoContainer.songs)
-  return _add;
+inline bool SongDifficulty::has_notes() const {
+  return _internal_has_notes();
 }
-inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::SongDetailsCache::Structs::SongProto >&
-SongProtoContainer::songs() const {
-  // @@protoc_insertion_point(field_list:SongDetailsCache.Structs.SongProtoContainer.songs)
-  return _impl_.songs_;
+inline void SongDifficulty::clear_notes() {
+  _impl_.notes_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000020u;
+}
+inline uint32_t SongDifficulty::_internal_notes() const {
+  return _impl_.notes_;
+}
+inline uint32_t SongDifficulty::notes() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.notes)
+  return _internal_notes();
+}
+inline void SongDifficulty::_internal_set_notes(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000020u;
+  _impl_.notes_ = value;
+}
+inline void SongDifficulty::set_notes(uint32_t value) {
+  _internal_set_notes(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.notes)
+}
+
+// optional uint32 obstacles = 9;
+inline bool SongDifficulty::_internal_has_obstacles() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000040u) != 0;
+  return value;
+}
+inline bool SongDifficulty::has_obstacles() const {
+  return _internal_has_obstacles();
+}
+inline void SongDifficulty::clear_obstacles() {
+  _impl_.obstacles_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000040u;
+}
+inline uint32_t SongDifficulty::_internal_obstacles() const {
+  return _impl_.obstacles_;
+}
+inline uint32_t SongDifficulty::obstacles() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.obstacles)
+  return _internal_obstacles();
+}
+inline void SongDifficulty::_internal_set_obstacles(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000040u;
+  _impl_.obstacles_ = value;
+}
+inline void SongDifficulty::set_obstacles(uint32_t value) {
+  _internal_set_obstacles(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.obstacles)
+}
+
+// optional uint32 mods = 10;
+inline bool SongDifficulty::_internal_has_mods() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000080u) != 0;
+  return value;
+}
+inline bool SongDifficulty::has_mods() const {
+  return _internal_has_mods();
+}
+inline void SongDifficulty::clear_mods() {
+  _impl_.mods_ = 0u;
+  _impl_._has_bits_[0] &= ~0x00000080u;
+}
+inline uint32_t SongDifficulty::_internal_mods() const {
+  return _impl_.mods_;
+}
+inline uint32_t SongDifficulty::mods() const {
+  // @@protoc_insertion_point(field_get:SongDetailsCache.Structs.SongDifficulty.mods)
+  return _internal_mods();
+}
+inline void SongDifficulty::_internal_set_mods(uint32_t value) {
+  _impl_._has_bits_[0] |= 0x00000080u;
+  _impl_.mods_ = value;
+}
+inline void SongDifficulty::set_mods(uint32_t value) {
+  _internal_set_mods(value);
+  // @@protoc_insertion_point(field_set:SongDetailsCache.Structs.SongDifficulty.mods)
 }
 
 #ifdef __GNUC__
@@ -1670,6 +2105,31 @@ SongProtoContainer::songs() const {
 
 }  // namespace Structs
 }  // namespace SongDetailsCache
+
+PROTOBUF_NAMESPACE_OPEN
+
+template <> struct is_proto_enum< ::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic>() {
+  return ::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic_descriptor();
+}
+template <> struct is_proto_enum< ::SongDetailsCache::Structs::SongDifficulty_MapDifficulty> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::SongDetailsCache::Structs::SongDifficulty_MapDifficulty>() {
+  return ::SongDetailsCache::Structs::SongDifficulty_MapDifficulty_descriptor();
+}
+template <> struct is_proto_enum< ::SongDetailsCache::Structs::RankedStatusBitflags> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::SongDetailsCache::Structs::RankedStatusBitflags>() {
+  return ::SongDetailsCache::Structs::RankedStatusBitflags_descriptor();
+}
+template <> struct is_proto_enum< ::SongDetailsCache::Structs::UploadFlags> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::SongDetailsCache::Structs::UploadFlags>() {
+  return ::SongDetailsCache::Structs::UploadFlags_descriptor();
+}
+
+PROTOBUF_NAMESPACE_CLOSE
 
 // @@protoc_insertion_point(global_scope)
 

--- a/include/SongProto.pb.h
+++ b/include/SongProto.pb.h
@@ -155,14 +155,15 @@ inline bool RankedStatusBitflags_Parse(
 }
 enum UploadFlags : int {
   None = 0,
-  VerifiedUploader = 1,
-  Curated = 2,
+  CuratedMap = 1,
+  VerifiedUploader = 2,
+  HasV3Environment = 4,
   UploadFlags_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
   UploadFlags_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
 };
 bool UploadFlags_IsValid(int value);
 constexpr UploadFlags UploadFlags_MIN = None;
-constexpr UploadFlags UploadFlags_MAX = Curated;
+constexpr UploadFlags UploadFlags_MAX = HasV3Environment;
 constexpr int UploadFlags_ARRAYSIZE = UploadFlags_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* UploadFlags_descriptor();

--- a/include/SongProto.proto
+++ b/include/SongProto.proto
@@ -20,8 +20,9 @@ enum RankedStatusBitflags {
 
 enum UploadFlags {
 	None = 0;
-	VerifiedUploader = 1;
-	Curated = 2;
+	CuratedMap = 1;
+	VerifiedUploader = 2;
+	HasV3Environment = 4;
 }
 
 message SongV3 {

--- a/include/SongProto.proto
+++ b/include/SongProto.proto
@@ -2,39 +2,83 @@ syntax="proto3";
 
 package SongDetailsCache.Structs;
 
-message SongDifficultyProto {
-    optional uint32 characteristic = 1;
-    optional uint32 difficulty = 2;
-    uint32 starsT100 = 4;
-    uint32 starsT100BL = 5;
-    uint32 njsT100 = 6;
-    uint32 bombs = 7;
-    uint32 notes = 8;
-    uint32 obstacles = 9;
-    optional uint32 mods = 10;
+message SongDetailsV3 {
+	uint32 formatVersion = 1;
+	uint32 scrapeEndedUnix = 2;
+	bytes songHashes = 3;
+	repeated SongV3 songs = 4;
+	repeated string tagList = 5;
 }
 
-message SongProto {
-    float bpm = 1;
-    uint32 downloadCount = 2;
-    uint32 upvotes = 3;
-    uint32 downvotes = 4;
-    uint32 uploadTimeUnix = 5;
-    uint32 rankedChangeUnix = 14;
-    uint32 mapId = 6;
-    uint32 songDurationSeconds = 8;
-    bytes hashBytes = 9;
-    string songName = 10;
-    string songAuthorName = 11;
-    string levelAuthorName = 12;
-    optional uint32 rankedState = 15;
-    repeated SongDifficultyProto difficulties = 13;
-    string uploaderName = 16;
-    optional uint32 rankedStates = 17;
+enum RankedStatusBitflags {
+	Unranked = 0;
+	RankedSS = 1;
+	RankedBL = 2;
+	QualifiedSS = 4;
+	QualifiedBL = 8;
 }
 
-message SongProtoContainer {
-    uint32 formatVersion = 1;
-    uint64 scrapeEndedTimeUnix = 2;
-    repeated SongProto songs = 4;
+enum UploadFlags {
+	None = 0;
+	VerifiedUploader = 1;
+	Curated = 2;
+}
+
+message SongV3 {
+	float bpm = 1;
+	optional uint32 upvotes = 2;
+	optional uint32 downvotes = 3;
+
+	uint32 uploadTimeUnix = 4;
+
+	uint32 mapId = 5;
+
+	optional uint32 songDurationSeconds = 6;
+
+	string songName = 7;
+	string songAuthorName = 8;
+	string levelAuthorName = 9;
+	optional string uploaderName = 10;
+
+	repeated SongDifficulty difficulties = 11;
+
+	optional uint32 rankedChangeUnix = 12;
+	optional RankedStatusBitflags rankedStateBitflags = 13;
+	optional uint64 tags = 14;
+	optional UploadFlags uploadFlags = 15;
+}
+
+message SongDifficulty {
+	enum MapCharacteristic {
+		Custom = 0;
+		Standard = 1;
+		OneSaber = 2;
+		NoArrows = 3;
+		NinetyDegree = 4;
+		ThreeSixtyDegree = 5;
+		Lightshow = 6;
+		Lawless = 7;
+	}
+
+	enum MapDifficulty {
+		Easy = 0;
+		Normal = 1;
+		Hard = 2;
+		Expert = 3;
+		ExpertPlus = 4;
+	}
+
+	optional MapCharacteristic characteristic = 1;
+	optional MapDifficulty difficulty = 2;
+
+	optional uint32 starsT100 = 4;
+	optional uint32 starsT100BL = 5;
+
+	uint32 njsT100 = 6;
+
+	optional uint32 bombs = 7;
+	optional uint32 notes = 8;
+	optional uint32 obstacles = 9;
+
+	optional uint32 mods = 10;
 }

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <string_view>
-#include "paper/shared/logger.hpp"
+#include "paper2_scotland2/shared/logger.hpp"
 
 #define INFO(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::INF>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))
 #define ERROR(str, ...) Paper::Logger::fmtLogTag<Paper::LogLevel::ERR>(str, "SongDetails" __VA_OPT__(, __VA_ARGS__))

--- a/qpm.json
+++ b/qpm.json
@@ -47,7 +47,7 @@
         "pwsh ./scripts/log.ps1"
       ],
       "qmod": [
-        "pwsh ./scripts/build.ps1 -clean",
+        "pwsh ./scripts/build.ps1 -clean -release",
         "qpm qmod manifest",
         "pwsh ./scripts/createqmod.ps1 SongDetails -clean"
       ]

--- a/qpm.json
+++ b/qpm.json
@@ -13,11 +13,6 @@
   },
   "dependencies": [
     {
-      "id": "beatsaber-hook",
-      "versionRange": "^5.1.9",
-      "additionalData": {}
-    },
-    {
       "id": "libcurl",
       "versionRange": "^7.78.0",
       "additionalData": {
@@ -25,8 +20,8 @@
       }
     },
     {
-      "id": "paper",
-      "versionRange": "^3.6.3",
+      "id": "paper2_scotland2",
+      "versionRange": "^4.3.0",
       "additionalData": {
         "private": true
       }

--- a/qpm.json
+++ b/qpm.json
@@ -4,7 +4,7 @@
   "info": {
     "name": "SongDetails",
     "id": "song-details",
-    "version": "0.3.7",
+    "version": "1.0.0",
     "url": "https://github.com/bsq-ports/SongDetails",
     "additionalData": {
       "overrideSoName": "libsongdetails.so",

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -6,7 +6,7 @@
     "info": {
       "name": "SongDetails",
       "id": "song-details",
-      "version": "0.3.7",
+      "version": "1.0.0",
       "url": "https://github.com/bsq-ports/SongDetails",
       "additionalData": {
         "overrideSoName": "libsongdetails.so",

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -28,7 +28,7 @@
           "pwsh ./scripts/log.ps1"
         ],
         "qmod": [
-          "pwsh ./scripts/build.ps1 -clean",
+          "pwsh ./scripts/build.ps1 -clean -release",
           "qpm qmod manifest",
           "pwsh ./scripts/createqmod.ps1 SongDetails -clean"
         ]
@@ -39,11 +39,6 @@
     },
     "dependencies": [
       {
-        "id": "beatsaber-hook",
-        "versionRange": "^5.1.9",
-        "additionalData": {}
-      },
-      {
         "id": "libcurl",
         "versionRange": "^7.78.0",
         "additionalData": {
@@ -51,8 +46,8 @@
         }
       },
       {
-        "id": "paper",
-        "versionRange": "^3.6.3",
+        "id": "paper2_scotland2",
+        "versionRange": "^4.3.0",
         "additionalData": {
           "private": true
         }
@@ -62,14 +57,13 @@
   "restoredDependencies": [
     {
       "dependency": {
-        "id": "paper",
-        "versionRange": "=3.7.0",
+        "id": "paper2_scotland2",
+        "versionRange": "=4.3.0",
         "additionalData": {
-          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.7.0/libpaperlog.so",
-          "debugSoLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.7.0/debug_libpaperlog.so",
-          "overrideSoName": "libpaperlog.so",
-          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.7.0/paperlog.qmod",
-          "branchName": "version/v3_7_0",
+          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.3.0/libpaper2_scotland2.so",
+          "overrideSoName": "libpaper2_scotland2.so",
+          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.3.0/paper2_scotland2.qmod",
+          "branchName": "version/v4_3_0",
           "compileOptions": {
             "systemIncludes": [
               "shared/utfcpp/source"
@@ -78,18 +72,7 @@
           "cmake": false
         }
       },
-      "version": "3.7.0"
-    },
-    {
-      "dependency": {
-        "id": "libil2cpp",
-        "versionRange": "=0.3.2",
-        "additionalData": {
-          "headersOnly": true,
-          "cmake": false
-        }
-      },
-      "version": "0.3.2"
+      "version": "4.3.0"
     },
     {
       "dependency": {
@@ -103,32 +86,6 @@
         }
       },
       "version": "7.78.0"
-    },
-    {
-      "dependency": {
-        "id": "beatsaber-hook",
-        "versionRange": "=5.1.9",
-        "additionalData": {
-          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.1.9/libbeatsaber-hook_5_1_9.so",
-          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.1.9/debug_libbeatsaber-hook_5_1_9.so",
-          "branchName": "version/v5_1_9",
-          "cmake": true
-        }
-      },
-      "version": "5.1.9"
-    },
-    {
-      "dependency": {
-        "id": "scotland2",
-        "versionRange": "=0.1.4",
-        "additionalData": {
-          "soLink": "https://github.com/sc2ad/scotland2/releases/download/v0.1.4/libsl2.so",
-          "debugSoLink": "https://github.com/sc2ad/scotland2/releases/download/v0.1.4/debug_libsl2.so",
-          "overrideSoName": "libsl2.so",
-          "branchName": "version/v0_1_4"
-        }
-      },
-      "version": "0.1.4"
     },
     {
       "dependency": {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -22,6 +22,9 @@ if (($clean.IsPresent) -or (-not (Test-Path -Path "build")))
 $buildType = "Debug"
 if ($release.IsPresent) {
     $buildType = "RelWithDebInfo"
+    echo "Building release"
+} else {
+    echo "Building debug"
 }
 
 & cmake -G "Ninja" -DCMAKE_BUILD_TYPE="$buildType" -B ./build -S .

--- a/scripts/copy.ps1
+++ b/scripts/copy.ps1
@@ -2,10 +2,12 @@ param (
     [Parameter(Mandatory=$false)]
     [Switch]$debug_so,
     [Parameter(Mandatory=$false)]
-    [Switch]$log
+    [Switch]$log,
+    [Parameter(Mandatory=$false)]
+    [Switch]$release
 )
 
-& $PSScriptRoot/build.ps1
+& $PSScriptRoot/build.ps1 -release:$release
 if (-not ($LastExitCode -eq 0)) {
     echo "build failed, not copying"
     exit

--- a/scripts/copy.ps1
+++ b/scripts/copy.ps1
@@ -12,9 +12,9 @@ if (-not ($LastExitCode -eq 0)) {
 }
 
 if ($debug_so.IsPresent) {
-    & adb push build/debug/libsongdetails.so /sdcard/Android/data/com.beatgames.beatsaber/files/libs/libsongdetails.so
+    & adb push build/debug/libsongdetails.so /sdcard/ModData/com.beatgames.beatsaber/Modloader/libs/libsongdetails.so
 } else {
-    & adb push build/libsongdetails.so /sdcard/Android/data/com.beatgames.beatsaber/files/libs/libsongdetails.so
+    & adb push build/libsongdetails.so /sdcard/ModData/com.beatgames.beatsaber/Modloader/libs/libsongdetails.so
 }
 
 & adb shell am force-stop com.beatgames.beatsaber

--- a/scripts/ndk-stack.ps1
+++ b/scripts/ndk-stack.ps1
@@ -1,0 +1,13 @@
+if (Test-Path "./ndkpath.txt")
+{
+    $NDKPath = Get-Content ./ndkpath.txt
+} else {
+    $NDKPath = $ENV:ANDROID_NDK_HOME
+}
+
+$stackScript = "$NDKPath/ndk-stack"
+if (-not ($PSVersionTable.PSEdition -eq "Core")) {
+    $stackScript += ".cmd"
+}
+
+Get-Content ./log.log | & $stackScript -sym ./build/debug/ > log_unstripped.log

--- a/shared/Data/RankedStatus.hpp
+++ b/shared/Data/RankedStatus.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "RankedStates.hpp"
+
 #include "../_config.h"
 
 namespace SongDetailsCache {
@@ -9,6 +11,12 @@ namespace SongDetailsCache {
         Qualified = 2,
         Queued = 3,
     };
+
+    static RankedStatus RankedStatusFromRankedStates(RankedStates states) {
+        if (hasFlags(states, RankedStates::ScoresaberRanked)) return RankedStatus::Ranked;
+        if (hasFlags(states, RankedStates::ScoresaberQualified)) return RankedStatus::Qualified;
+        return RankedStatus::Unranked;
+    }
 }
 
 // if we have fmt, add formatting methods

--- a/shared/Data/Song.hpp
+++ b/shared/Data/Song.hpp
@@ -13,14 +13,12 @@
 
 namespace SongDetailsCache {
     namespace Structs {
-        struct SongProto;
+        struct SongV3;
     }
     struct SONGDETAILS_EXPORT Song {
         public:
             /// @brief bpm of this map
             const float bpm;
-            /// @brief download count of this map
-            const uint32_t downloadCount;
             /// @brief upvotes of this map
             const uint32_t upvotes;
             /// @brief downvotes of this map
@@ -77,9 +75,6 @@ namespace SongDetailsCache {
             std::string key() const noexcept;
             /// @return Numeric representation of the Map ID
             uint32_t mapId() const noexcept;
-
-            /// @brief Ranked status of the map on ScoreSaber
-            const RankedStatus rankedStatus;
 
             /// @brief Ranked state of the map on both ScoreSaber and BeatLeader (bitwise mask)
             const RankedStates rankedStates;
@@ -145,7 +140,7 @@ namespace SongDetailsCache {
             /// @brief delete copy constructor
             Song(const Song&) = delete;
             /// @brief this needs to be public for specific reasons, but it's not advised to make your own SongDetail::Songs!
-            Song(std::size_t index, std::size_t diffOffset, uint8_t diffCount, const Structs::SongProto* proto) noexcept;
+            Song(std::size_t index, std::size_t diffOffset, uint8_t diffCount, const Structs::SongV3* proto) noexcept;
         private:
             friend class SongDetailsContainer;
             friend class SongDetails;

--- a/shared/Data/Song.hpp
+++ b/shared/Data/Song.hpp
@@ -111,6 +111,10 @@ namespace SongDetailsCache {
                 return this != &none;
             }
 
+            /// @brief Helper method to check if the Song has a tag set
+            /// @param tag string representation of the BeatSaver Tag
+            /// @return whether the tag is set
+            bool HasTag(std::string_view tag) const noexcept;
             /// @brief Helper function to get a difficulty from this song
             /// @param outDiff a reference to the output pointer
             /// @param diff the difficulty to search for

--- a/shared/Data/Song.hpp
+++ b/shared/Data/Song.hpp
@@ -81,6 +81,8 @@ namespace SongDetailsCache {
             /// @return Numeric representation of the Map ID
             uint32_t mapId() const noexcept;
 
+            /// @brief Ranked status of the map on ScoreSaber
+            const RankedStatus rankedStatus;
             /// @brief Ranked state of the map on both ScoreSaber and BeatLeader (bitwise mask)
             const RankedStates rankedStates;
 

--- a/shared/Data/Song.hpp
+++ b/shared/Data/Song.hpp
@@ -4,6 +4,7 @@
 #include "SongDifficulty.hpp"
 #include "RankedStatus.hpp"
 #include "RankedStates.hpp"
+#include "UploadFlags.hpp"
 
 #include <chrono>
 #include <functional>
@@ -23,6 +24,10 @@ namespace SongDetailsCache {
             const uint32_t upvotes;
             /// @brief downvotes of this map
             const uint32_t downvotes;
+            /// @brief Upload flags of this map
+            const UploadFlags uploadFlags;
+            /// @brief Raw tags of this map
+            const uint64_t tags;
 
             /// @brief get the minimum of some value you want to know the minimum of for all the diffs of this song
             /// @param func the lambda that returns the value

--- a/shared/Data/SongDifficulty.hpp
+++ b/shared/Data/SongDifficulty.hpp
@@ -8,7 +8,7 @@
 
 namespace SongDetailsCache {
     namespace Structs {
-        struct SongDifficultyProto;
+        struct SongDifficulty;
     };
     struct SONGDETAILS_EXPORT Song;
     struct SONGDETAILS_EXPORT SongDifficulty {
@@ -69,7 +69,7 @@ namespace SongDetailsCache {
             SongDifficulty(const SongDifficulty&) = delete;
 
             /// @brief This needs to be public for specific reasons, but it's not advised to make your own SongDifficulties
-            SongDifficulty(std::size_t songIndex, const Structs::SongDifficultyProto* proto) noexcept;
+            SongDifficulty(std::size_t songIndex, const Structs::SongDifficulty* proto) noexcept;
         private:
             friend class SongDetailsContainer;
             friend class SongDetails;

--- a/shared/Data/SongDifficulty.hpp
+++ b/shared/Data/SongDifficulty.hpp
@@ -45,9 +45,6 @@ namespace SongDetailsCache {
             /// @brief Returns if the Difficulty is ranked on Scoresaber
             bool rankedSS() const noexcept;
 
-            /// @brief Returns the PP value of a 95% Accuracy score
-            float approximatePpValue() const noexcept;
-
             /// @brief shorthand to check the mods enum
             bool usesMods(const MapMods& usedMods) const noexcept;
 

--- a/shared/Data/UploadFlags.hpp
+++ b/shared/Data/UploadFlags.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "../_config.h"
+#include <vector>
+
+namespace SongDetailsCache {
+
+    /// @brief Enum describing what ranked states a map can be in
+    enum class SONGDETAILS_EXPORT UploadFlags {
+        None =                 0,
+        Curated =              1 << 0,
+        VerifiedUploader =     1 << 1,
+    };
+
+    static constexpr UploadFlags operator |(const UploadFlags& lhs, const UploadFlags& rhs) {
+        return static_cast<UploadFlags>(static_cast<int>(lhs) | static_cast<int>(rhs));
+    }
+    static constexpr UploadFlags& operator |=(UploadFlags& lhs, const UploadFlags& rhs) {
+        lhs = lhs | rhs;
+        return lhs;
+    }
+
+    static constexpr UploadFlags operator &(const UploadFlags& lhs, const UploadFlags& rhs) {
+        return static_cast<UploadFlags>(static_cast<int>(lhs) & static_cast<int>(rhs));
+    }
+    static constexpr  UploadFlags& operator &=(UploadFlags& lhs, const UploadFlags& rhs) {
+        lhs = lhs & rhs;
+        return lhs;
+    }
+
+    static constexpr  bool hasFlags(const UploadFlags& lhs, const UploadFlags& rhs) {
+        return (lhs & rhs) == rhs;
+    }
+
+    static std::vector<std::string> toVectorOfStrings(const UploadFlags& states) {
+        std::vector<std::string> result{};
+        if (hasFlags(states, UploadFlags::None)) result.emplace_back("None");
+        if (hasFlags(states, UploadFlags::Curated)) result.emplace_back("Curated");
+        if (hasFlags(states, UploadFlags::VerifiedUploader)) result.emplace_back("VerifiedUploader");
+        return result;
+    }
+}
+
+// if we have fmt, add formatting methods
+#if __has_include("fmt/core.h")
+#include <fmt/core.h>
+#include <sstream>
+template <> struct SONGDETAILS_EXPORT fmt::formatter<::SongDetailsCache::UploadFlags> : formatter<string_view> {
+    // parse is inherited from formatter<string_view>.
+    template <typename FormatContext>
+    auto format(::SongDetailsCache::UploadFlags s, FormatContext& ctx) {
+
+        std::string result;
+        if (hasFlags(s, SongDetailsCache::UploadFlags::Curated) ) {
+            result += "Curated";
+        }
+        if (hasFlags(s, SongDetailsCache::UploadFlags::VerifiedUploader) ) {
+            if (!result.empty()) {
+                result += " | ";
+            }
+            result += "VerifiedUploader";
+        }
+        if (result.empty()) {
+            result = "None";
+        }
+
+        return formatter<string_view>::format(result, ctx);
+    }
+};
+#endif

--- a/shared/Data/UploadFlags.hpp
+++ b/shared/Data/UploadFlags.hpp
@@ -10,6 +10,7 @@ namespace SongDetailsCache {
         None =                 0,
         Curated =              1 << 0,
         VerifiedUploader =     1 << 1,
+        HasV3Environment =     1 << 2,
     };
 
     static constexpr UploadFlags operator |(const UploadFlags& lhs, const UploadFlags& rhs) {
@@ -37,6 +38,7 @@ namespace SongDetailsCache {
         if (hasFlags(states, UploadFlags::None)) result.emplace_back("None");
         if (hasFlags(states, UploadFlags::Curated)) result.emplace_back("Curated");
         if (hasFlags(states, UploadFlags::VerifiedUploader)) result.emplace_back("VerifiedUploader");
+        if (hasFlags(states, UploadFlags::HasV3Environment)) result.emplace_back("HasV3Environment");
         return result;
     }
 }
@@ -59,6 +61,12 @@ template <> struct SONGDETAILS_EXPORT fmt::formatter<::SongDetailsCache::UploadF
                 result += " | ";
             }
             result += "VerifiedUploader";
+        }
+        if (hasFlags(s, SongDetailsCache::UploadFlags::HasV3Environment) ) {
+            if (!result.empty()) {
+                result += " | ";
+            }
+            result += "HasV3Environment";
         }
         if (result.empty()) {
             result = "None";

--- a/shared/SongDetails.hpp
+++ b/shared/SongDetails.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "./_config.h"
-#include "beatsaber-hook/shared/utils/typedefs-wrappers.hpp"
+#include "bshook-utils.hpp"
 #include "Data/Song.hpp"
 #include "Data/SongDifficulty.hpp"
 #include "SongArray.hpp"
@@ -38,10 +38,10 @@ namespace SongDetailsCache {
             std::chrono::sys_seconds get_scrapeEndedTimeUnix() const;
 
             /// @brief Invoked when data is available or was updated
-            static UnorderedEventCallback<> dataAvailableOrUpdated;
+            static BSHookUtils::UnorderedEventCallback<> dataAvailableOrUpdated;
 
             /// @brief Invoked when data failed to load
-            static UnorderedEventCallback<std::string> dataLoadFailed;
+            static BSHookUtils::UnorderedEventCallback<std::string> dataLoadFailed;
         private:
             SongDetails() noexcept;
             static void DataAvailableOrUpdated();

--- a/shared/SongDetails.hpp
+++ b/shared/SongDetails.hpp
@@ -41,11 +41,11 @@ namespace SongDetailsCache {
             static UnorderedEventCallback<> dataAvailableOrUpdated;
 
             /// @brief Invoked when data failed to load
-            static UnorderedEventCallback<> dataLoadFailed;
+            static UnorderedEventCallback<std::string> dataLoadFailed;
         private:
             SongDetails() noexcept;
             static void DataAvailableOrUpdated();
-            static void DataLoadFailed();
+            static void DataLoadFailed(std::string message);
 
             friend class SongDetailsContainer;
             static bool isLoading;

--- a/shared/bshook-utils.hpp
+++ b/shared/bshook-utils.hpp
@@ -1,0 +1,285 @@
+#pragma once
+#include <concepts>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <shared_mutex>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include <optional>
+
+
+namespace BSHookUtils {
+    
+/// @brief Represents a pointer that may be GC'd, but will notify you when it has.
+/// Currently unimplemented, requires a hook into all GC frees/collections
+template <class T>
+struct WeakPtr {};
+
+template <template <typename> typename Container, typename Item>
+concept is_valid_container = requires(Container<Item> coll, Item item) {
+                                 coll.erase(item);
+                                 coll.emplace(item);
+                                 coll.clear();
+                                 coll.begin();
+                                 coll.end();
+                                 coll.size();
+                             };
+
+template <class T>
+struct AbstractFunction;
+
+template <typename R, typename T, typename... TArgs>
+struct AbstractFunction<R(T*, TArgs...)> {
+    virtual T* instance() const = 0;
+    virtual void* ptr() const = 0;
+
+    virtual R operator()(TArgs... args) const noexcept = 0;
+    virtual ~AbstractFunction() = default;
+};
+
+template <class T>
+struct FunctionWrapper;
+
+template <typename R, typename... TArgs>
+struct FunctionWrapper<R (*)(TArgs...)> : AbstractFunction<R(void*, TArgs...)> {
+    void* instance() const override {
+        return nullptr;
+    }
+    void* ptr() const override {
+        return reinterpret_cast<void*>(held);
+    }
+    R (*held)(TArgs...);
+    template <class F>
+    FunctionWrapper(F&& f) : held(f) {}
+    R operator()(TArgs... args) const noexcept override {
+        if constexpr (std::is_same_v<R, void>) {
+            held(args...);
+        } else {
+            return held(args...);
+        }
+    }
+};
+
+template <typename R, typename T, typename... TArgs>
+struct FunctionWrapper<R (T::*)(TArgs...)> : AbstractFunction<R(void*, TArgs...)> {
+    void* instance() const override {
+        return _instance;
+    }
+    void* ptr() const override {
+        using fptr = R (T::*)(TArgs...);
+        union dat {
+            fptr wrapper;
+            void* data;
+        };
+        dat d{ .wrapper = held };
+        return d.data;
+    }
+    R (T::*held)(TArgs...);
+    T* _instance;
+    template <class F>
+    FunctionWrapper(F&& f, T* inst) : held(f), _instance(inst) {}
+    R operator()(TArgs... args) const noexcept override {
+        if constexpr (std::is_same_v<R, void>) {
+            (reinterpret_cast<T*>(_instance)->*held)(args...);
+        } else {
+            return (reinterpret_cast<T*>(_instance)->*held)(args...);
+        }
+    }
+};
+
+template <typename R, typename... TArgs>
+struct FunctionWrapper<std::function<R(TArgs...)>> : AbstractFunction<R(void*, TArgs...)> {
+    [[nodiscard]] void* instance() const override {
+        return nullptr;
+    }
+    [[nodiscard]] void* ptr() const override {
+        return handle;
+    }
+    std::function<R(TArgs...)> const held;
+    void* handle;
+
+    FunctionWrapper(std::function<R(TArgs...)> const& f) : held(f), handle(const_cast<void*>(reinterpret_cast<const void*>(&f))) {}
+    R operator()(TArgs... args) const noexcept override {
+        if constexpr (std::is_same_v<R, void>) {
+            held(args...);
+        } else {
+            return held(args...);
+        }
+    }
+};
+
+
+template <typename R, typename T, typename... TArgs>
+bool operator==(const AbstractFunction<R(T*, TArgs...)>& a, const AbstractFunction<R(T*, TArgs...)>& b) {
+    return a.instance() == b.instance() && a.ptr() == b.ptr();
+}
+
+template <typename R, typename T, typename... TArgs>
+bool operator<(const AbstractFunction<R(T*, TArgs...)>& a, const AbstractFunction<R(T*, TArgs...)>& b) {
+    return a.ptr() < b.ptr();
+}
+
+template <class T>
+struct ThinVirtualLayer;
+
+
+template <typename R, typename T, typename... TArgs>
+struct ThinVirtualLayer<R(T*, TArgs...)> {
+    friend struct std::hash<ThinVirtualLayer<R(T*, TArgs...)>>;
+
+   private:
+    std::shared_ptr<AbstractFunction<R(T*, TArgs...)>> func;
+
+   public:
+    ThinVirtualLayer(R (*ptr)(TArgs...)) : func(new FunctionWrapper<R (*)(TArgs...)>(ptr)) {}
+    template <class F, typename Q>
+    ThinVirtualLayer(F&& f, Q* inst) : func(new FunctionWrapper<R (Q::*)(TArgs...)>(f, inst)) {}
+    template <class F>
+    ThinVirtualLayer(F&& f) : func(new FunctionWrapper<std::function<R(TArgs...)>>(f)) {}
+
+    R operator()(TArgs... args) const noexcept {
+        (*func)(args...);
+    }
+    void* instance() const {
+        return func->instance();
+    }
+    void* ptr() const {
+        return func->ptr();
+    }
+
+    bool operator==(const ThinVirtualLayer<R(T*, TArgs...)> other) const {
+        return *func == (*other.func);
+    }
+    bool operator<(const ThinVirtualLayer<R(T*, TArgs...)> other) const {
+        return *func < *other.func;
+    }
+};
+
+
+
+// TODO: Make a version of this for C# delegates?
+// TODO: Also require the function type to be invokable and all that
+template <template <typename> typename Container, typename... TArgs>
+    requires(is_valid_container<Container, ThinVirtualLayer<void(void*, TArgs...)>>)
+class BasicEventCallback {
+   private:
+    using functionType = ThinVirtualLayer<void(void*, TArgs...)>;
+    Container<functionType> callbacks;
+
+   public:
+    void invoke(TArgs... args) const {
+#ifndef NO_EVENT_CALLBACK_INVOKE_SAFETY
+        // copy the callbacks so an unsubscribe during invoke of the container doesn't cause UB
+        auto cbs = callbacks;
+        for (auto& callback : cbs) {
+            callback(args...);
+        }
+#else
+        // no safety requested, just run it from the callbacks as
+        for (auto& callback : callbacks) {
+            callback(args...);
+        }
+#endif
+    }
+
+    BasicEventCallback& operator+=(ThinVirtualLayer<void(void*, TArgs...)> callback) {
+        callbacks.emplace(std::move(callback));
+        return *this;
+    }
+
+    BasicEventCallback& operator-=(void (*callback)(TArgs...)) {
+        removeCallback(callback);
+        return *this;
+    }
+
+    BasicEventCallback& operator-=(ThinVirtualLayer<void(void*, TArgs...)> callback) {
+        callbacks.erase(callback);
+        return *this;
+    }
+
+    template <typename T>
+    BasicEventCallback& operator-=(void (T::*callback)(TArgs...)) {
+        removeCallback(callback);
+        return *this;
+    }
+
+    void addCallback(void (*callback)(TArgs...)) {
+        callbacks.emplace(callback);
+    }
+    // The instance provide here should have lifetime > calls to invoke.
+    // If the provided instance dies before this instance, or before invoke is called, invoke will crash.
+    template <typename T>
+    void addCallback(void (T::*callback)(TArgs...), T* inst) {
+        callbacks.emplace(callback, inst);
+    }
+
+    void removeCallback(void (*callback)(TArgs...)) {
+        callbacks.erase(callback);
+    }
+
+    template <typename T>
+    void removeCallback(void (T::*callback)(TArgs...)) {
+        // Removal of member functions is expensive because we need to remove all member functions regardless of instance
+        for (auto itr = callbacks.begin(); itr != callbacks.end();) {
+            union dat {
+                decltype(callback) wrapper;
+                void* data;
+            };
+            dat d{ .wrapper = callback };
+            if (itr->ptr() == d.data) {
+                itr = callbacks.erase(itr);
+            } else {
+                ++itr;
+            }
+        }
+    }
+    auto size() const {
+        return callbacks.size();
+    }
+    void clear() {
+        callbacks.clear();
+    }
+};
+#undef __SAFE_PTR_NULL_HANDLE_CHECK
+
+template <typename Item>
+using default_ordered_set = std::set<Item>;
+
+template <typename Item>
+using default_unordered_set = std::unordered_set<Item>;
+
+// Good default for most
+template <typename... TArgs>
+using EventCallback = BasicEventCallback<default_ordered_set, TArgs...>;
+
+template <typename... TArgs>
+using UnorderedEventCallback = BasicEventCallback<default_unordered_set, TArgs...>;
+
+}  // namespace BSHookUtils
+
+
+namespace std {
+    template <typename R, typename T, typename... TArgs>
+    struct std::hash<BSHookUtils::ThinVirtualLayer<R(T*, TArgs...)>>;
+
+    template <typename R, typename T, typename... TArgs>
+    struct hash<BSHookUtils::ThinVirtualLayer<R(T*, TArgs...)>> {
+        std::size_t operator()(const BSHookUtils::ThinVirtualLayer<R(T*, TArgs...)>& obj) const noexcept {
+            return std::hash<BSHookUtils::AbstractFunction<R(T*, TArgs...)>>{}(*obj.func);
+        }
+    };
+
+    template <typename R, typename T, typename... TArgs>
+    struct hash<BSHookUtils::AbstractFunction<R(T*, TArgs...)>> {
+        std::size_t operator()(const BSHookUtils::AbstractFunction<R(T*, TArgs...)>& obj) const noexcept {
+            auto seed = std::hash<void*>{}(obj.instance());
+            return seed ^ std::hash<void*>{}(reinterpret_cast<void*>(obj.ptr())) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            return seed;
+        }
+    };
+}  // namespace std

--- a/src/Data/DataGetter.cpp
+++ b/src/Data/DataGetter.cpp
@@ -7,7 +7,7 @@
 #include <sstream>
 #include <fmt/core.h>
 #include <sys/stat.h>
-#include "gzip/decompress.hpp"
+#include "brotli/decode.h"
 
 namespace SongDetailsCache {
     std::filesystem::path DataGetter::basePath{"/sdcard/ModData/com.beatgames.beatsaber/Mods/SongDetails"};
@@ -18,8 +18,8 @@ namespace SongDetailsCache {
     // just copied from the C# binary (order from bottom to top)
     const std::unordered_map<std::string, std::string> DataGetter::dataSources {
 		// Caches stuff for 12 hours as backup
-		{ "JSDelivr", "https://cdn.jsdelivr.net/gh/kinsi55/BeatSaberScrappedData/songDetails2.gz" },
-        { "Direct", "https://raw.githubusercontent.com/kinsi55/BeatSaberScrappedData/master/songDetails2.gz" },
+		{ "JSDelivr", "https://cdn.jsdelivr.net/gh/kinsi55/BeatSaberScrappedData/songDetails2_v3.br" },
+        { "Direct", "https://raw.githubusercontent.com/kinsi55/BeatSaberScrappedData/master/songDetails2_v3.br" },
     };
 
     std::optional<std::ifstream> DataGetter::ReadCachedDatabase() {
@@ -44,6 +44,84 @@ namespace SongDetailsCache {
         }
 
         return false;
+    }
+
+    bool DataGetter::DecompressBrotli(std::vector<uint8_t>& out, const std::string& in) {
+        const size_t size = in.size();
+        const char* data = in.c_str();
+        if (size == 0) return false;
+
+        // Create decoder state
+        BrotliDecoderState* state = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
+        if (!state)
+            return false; // Could not create decoder state
+
+        const uint8_t* next_in = reinterpret_cast<const uint8_t*>(data);
+        size_t available_in = size;
+
+        const size_t chunk_size = 1024 * 1024 * 1;
+
+        // Clear the output vector to start fresh
+        out.clear();
+
+        // Variable for brotli to track available output space
+        size_t available_out = out.size();
+        uint8_t* next_out = &out[0];
+
+        // Total number of bytes written to the output buffer
+        size_t total_out = 0;
+
+        while (true) {
+            const size_t old_size = out.size();
+
+            // Reserve more space if we run out
+            if (available_out == 0) {
+                out.resize(old_size + chunk_size);
+                available_out = chunk_size;
+
+                // Remake the pointer to the new buffer
+                next_out = &out[total_out];
+            }
+
+            // Do the decompression
+            BrotliDecoderResult result = BrotliDecoderDecompressStream(
+                state,
+                &available_in,
+                &next_in,
+                &available_out,
+                &next_out,
+                &total_out
+            );
+
+            // Resize the vector to the actual number of bytes we wrote in this iteration
+            if (out.size() > total_out) {
+                out.resize(total_out);
+            }
+
+            if (result == BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT) {
+                // The decoder wants more input, but we have no more data left in `available_in`
+                if (available_in == 0) {
+                    BrotliDecoderDestroyInstance(state);
+                    return false; // Incomplete data
+                }
+                // Otherwise, if you’re streaming from a file or network, you’d load more here
+            }
+            else if (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
+                // Our buffer was completely filled, so we loop again to extend it
+                continue;
+            }
+            else if (result == BROTLI_DECODER_RESULT_SUCCESS) {
+                // Decompression successful
+                break;
+            }
+            else {
+                // Some error occurred
+                BrotliDecoderDestroyInstance(state);
+                return false;
+            }
+        }
+        BrotliDecoderDestroyInstance(state);
+        return true;
     }
 
     std::optional<DataGetter::DownloadedDatabase> DataGetter::UpdateAndReadDatabase_internal(std::string_view dataSourceName) {
@@ -97,11 +175,13 @@ namespace SongDetailsCache {
             }
         }
 
-        // decompress contents as gzip
+        // Decompress contents as brotli
         downloadedDatabase.data = std::make_shared<std::vector<uint8_t>>();
-        gzip::Decompressor decompressor{};
-        DEBUG("Decompressing data");
-        decompressor.decompress<std::vector<uint8_t>>(*downloadedDatabase.data, resp.content.c_str(), resp.content.size());
+        auto decompressOk = DecompressBrotli(*downloadedDatabase.data, resp.content);
+        if (!decompressOk) {
+            ERROR("Failed to decompress brotli data");
+            return std::nullopt;
+        }
 
         // DEBUG("Downloaded Database source   : {}", downloadedDatabase.source);
         // DEBUG("Downloaded Database etag     : {}", downloadedDatabase.etag);

--- a/src/Data/DataGetter.cpp
+++ b/src/Data/DataGetter.cpp
@@ -1,4 +1,5 @@
 #include "Data/DataGetter.hpp"
+#include "StopWatch.hpp"
 #include "Utils.hpp"
 #include "logging.hpp"
 
@@ -175,13 +176,14 @@ namespace SongDetailsCache {
         }
 
         // Decompress contents as brotli
+        StopWatch sw; sw.Start();
         downloadedDatabase.data = std::make_shared<std::vector<uint8_t>>();
         auto decompressOk = DecompressBrotli(*downloadedDatabase.data, resp.content);
         if (!decompressOk) {
             ERROR("Failed to decompress brotli data");
             return std::nullopt;
         }
-
+        INFO("Decompressed brotli data in {}ms", sw.EllapsedMilliseconds());
         // DEBUG("Downloaded Database source   : {}", downloadedDatabase.source);
         // DEBUG("Downloaded Database etag     : {}", downloadedDatabase.etag);
         // DEBUG("Downloaded Database data     : {}", fmt::ptr(downloadedDatabase.data->data()));

--- a/src/Data/Song.cpp
+++ b/src/Data/Song.cpp
@@ -18,7 +18,7 @@ namespace SongDetailsCache {
         rankedStates(static_cast<RankedStates>(proto && proto->has_rankedstatebitflags() ? proto->rankedstatebitflags() : 0)),
         uploadFlags(static_cast<UploadFlags>(proto && proto->has_uploadflags() ? proto->uploadflags(): 0)),
         tags(proto && proto->has_tags() ? proto->tags(): 0)
-        {}
+    {}
 
     float Song::min(std::function<float(const SongDifficulty&)> func) const {
         float min = std::numeric_limits<float>::max(); // for minimum, start with the highest value!
@@ -98,6 +98,17 @@ namespace SongDetailsCache {
         auto h = hash();
         std::transform(h.begin(), h.end(), h.begin(), [](auto c){ return std::tolower(c); });
         return fmt::format("https://cdn.beatsaver.com/{}.jpg", h);
+    }
+
+    bool Song::HasTag(std::string_view tag) const noexcept {
+        if (tag.empty() || tags == 0 || SongDetailsContainer::tags == nullptr) return false;
+
+        auto it = SongDetailsContainer::tags->find(tag.data());
+        if (it != SongDetailsContainer::tags->end()) {
+            return (it->second & tags) != 0;
+        }
+
+        return false;
     }
 
     bool Song::GetDifficulty(const SongDifficulty*& outDiff, MapDifficulty diff, MapCharacteristic characteristic) const noexcept {

--- a/src/Data/Song.cpp
+++ b/src/Data/Song.cpp
@@ -15,6 +15,11 @@ namespace SongDetailsCache {
         uploadTimeUnix(proto ? proto->uploadtimeunix() : 0),
         rankedChangeUnix(proto && proto->has_rankedchangeunix() ? proto->rankedchangeunix() : 0),
         songDurationSeconds(proto && proto->has_songdurationseconds() ? proto->songdurationseconds() : 0),
+        rankedStatus(
+            proto && proto->has_rankedstatebitflags() ?
+                RankedStatusFromRankedStates(static_cast<RankedStates>(proto->rankedstatebitflags()))
+                : RankedStatus::Unranked
+        ),
         rankedStates(static_cast<RankedStates>(proto && proto->has_rankedstatebitflags() ? proto->rankedstatebitflags() : 0)),
         uploadFlags(static_cast<UploadFlags>(proto && proto->has_uploadflags() ? proto->uploadflags(): 0)),
         tags(proto && proto->has_tags() ? proto->tags(): 0)

--- a/src/Data/Song.cpp
+++ b/src/Data/Song.cpp
@@ -10,12 +10,14 @@ namespace SongDetailsCache {
         diffOffset(diffOffset),
         diffCount(diffCount),
         bpm(proto ? proto->bpm() : 0),
-        upvotes(proto ? proto->upvotes() : 0),
-        downvotes(proto ? proto->downvotes() : 0),
+        upvotes(proto && proto->has_upvotes() ? proto->upvotes() : 0),
+        downvotes(proto && proto->has_downvotes() ? proto->downvotes() : 0),
         uploadTimeUnix(proto ? proto->uploadtimeunix() : 0),
-        rankedChangeUnix(proto ? proto->rankedchangeunix() : 0),
-        songDurationSeconds(proto ? proto->songdurationseconds() : 0),
-        rankedStates(static_cast<RankedStates>(proto ? proto->rankedstatebitflags() : 0))
+        rankedChangeUnix(proto && proto->has_rankedchangeunix() ? proto->rankedchangeunix() : 0),
+        songDurationSeconds(proto && proto->has_songdurationseconds() ? proto->songdurationseconds() : 0),
+        rankedStates(static_cast<RankedStates>(proto && proto->has_rankedstatebitflags() ? proto->rankedstatebitflags() : 0)),
+        uploadFlags(static_cast<UploadFlags>(proto && proto->has_uploadflags() ? proto->uploadflags(): 0)),
+        tags(proto && proto->has_tags() ? proto->tags(): 0)
         {}
 
     float Song::min(std::function<float(const SongDifficulty&)> func) const {
@@ -55,14 +57,7 @@ namespace SongDetailsCache {
         if (!hasFlags(rankedStates, RankedStates::ScoresaberRanked)) return 0.0f;
         return max([](const auto& diff){ return diff.starsSS; });
     }
-    float Song::minPP() const noexcept { 
-        if (!hasFlags(rankedStates, RankedStates::ScoresaberRanked)) return 0.0f;
-        return min([](const auto& diff){ return diff.rankedSS() ? diff.approximatePpValue() : std::numeric_limits<float>::max(); }); 
-    }
-    float Song::maxPP() const noexcept {
-        if (!hasFlags(rankedStates, RankedStates::ScoresaberRanked)) return 0.0f;
-        return max([](const auto& diff){ return diff.approximatePpValue(); }); 
-    }
+
     std::chrono::sys_time<std::chrono::seconds> Song::uploadTime() const noexcept {
         return std::chrono::sys_time<std::chrono::seconds>(std::chrono::seconds(uploadTimeUnix));
     }

--- a/src/Data/Song.cpp
+++ b/src/Data/Song.cpp
@@ -5,19 +5,17 @@
 
 namespace SongDetailsCache {
     const Song Song::none(-1, 0, 0, nullptr);
-    Song::Song(std::size_t index, std::size_t diffOffset, uint8_t diffCount, const Structs::SongProto* proto) noexcept :
+    Song::Song(std::size_t index, std::size_t diffOffset, uint8_t diffCount, const Structs::SongV3* proto) noexcept :
         index(index),
         diffOffset(diffOffset),
         diffCount(diffCount),
         bpm(proto ? proto->bpm() : 0),
-        downloadCount(proto ? proto->downloadcount() : 0),
         upvotes(proto ? proto->upvotes() : 0),
         downvotes(proto ? proto->downvotes() : 0),
         uploadTimeUnix(proto ? proto->uploadtimeunix() : 0),
         rankedChangeUnix(proto ? proto->rankedchangeunix() : 0),
         songDurationSeconds(proto ? proto->songdurationseconds() : 0),
-        rankedStatus(static_cast<RankedStatus>(proto ? proto->rankedstate() : 0)),
-        rankedStates(static_cast<RankedStates>(proto ? proto->rankedstates() : 0))
+        rankedStates(static_cast<RankedStates>(proto ? proto->rankedstatebitflags() : 0))
         {}
 
     float Song::min(std::function<float(const SongDifficulty&)> func) const {

--- a/src/Data/SongDetailsContainer.cpp
+++ b/src/Data/SongDetailsContainer.cpp
@@ -15,7 +15,7 @@ namespace SongDetailsCache {
     shared_ptr_vector<std::string> SongDetailsContainer::songAuthorNames;
     shared_ptr_vector<std::string> SongDetailsContainer::levelAuthorNames;
     shared_ptr_vector<std::string> SongDetailsContainer::uploaderNames;
-    shared_ptr_map<std::string, uint64_t> tags;
+    shared_ptr_unordered_map<std::string, uint64_t> SongDetailsContainer::tags;
 
     std::chrono::sys_seconds SongDetailsContainer::scrapeEndedTimeUnix;
     std::chrono::seconds SongDetailsContainer::updateThrottle = std::chrono::seconds(0);
@@ -154,7 +154,7 @@ namespace SongDetailsCache {
         newLevelAuthorNames->reserve(len);
 		auto newUploaderNames = make_shared_vec<std::string>();
         newUploaderNames->reserve(len);
-        auto newTags = make_shared_map<std::string, uint64_t>();
+        auto newTags = shared_ptr_unordered_map<std::string, uint64_t>();
 
         auto newDiffs = make_shared_vec<SongDifficulty>();
         std::size_t diffLen = 0;

--- a/src/Data/SongDetailsContainer.cpp
+++ b/src/Data/SongDetailsContainer.cpp
@@ -129,16 +129,10 @@ namespace SongDetailsCache {
         const auto len = parsedField.size();
         StopWatch sw; sw.Start();
 
-        std::vector<const SongDetailsCache::Structs::SongV3*> parsed;
+        std::vector<const Structs::SongV3*> parsed;
         parsed.resize(len);
         INFO("Got {} songs in data", len);
         for (std::size_t idx = 0; const auto& s : parsedField) parsed[idx++] = &s;
-        // sort a copied vector
-        std::stable_sort(parsed.begin(), parsed.end(), [](auto lhs, auto rhs){
-            return lhs->mapid() < rhs->mapid();
-        });
-
-        INFO("Sorted input in {}ms", sw.EllapsedMilliseconds());
 
         // we run everything with resize so everything is already valid memory
         auto newSongs = make_shared_vec<Song>();
@@ -169,8 +163,6 @@ namespace SongDetailsCache {
 
         // Cast it to a vector of SongHashes
         auto songHashesRaw = reinterpret_cast<const SongHash*>(parsedContainer.songhashes().data());
-        // TODO: hashes are ordered by map, maps are ordered by id, maybe we can skip some calculations
-
         for (std::size_t i = 0; i < len; i++) {
             const auto& parsedSong = parsed[i];
             uint8_t diffCount = std::min(255, parsedSong->difficulties_size());

--- a/src/Data/SongDetailsContainer.cpp
+++ b/src/Data/SongDetailsContainer.cpp
@@ -154,7 +154,7 @@ namespace SongDetailsCache {
         newLevelAuthorNames->reserve(len);
 		auto newUploaderNames = make_shared_vec<std::string>();
         newUploaderNames->reserve(len);
-        auto newTags = shared_ptr_unordered_map<std::string, uint64_t>();
+        auto newTags = make_shared_unordered_map<std::string, uint64_t>();
 
         auto newDiffs = make_shared_vec<SongDifficulty>();
         std::size_t diffLen = 0;

--- a/src/Data/SongDetailsContainer.cpp
+++ b/src/Data/SongDetailsContainer.cpp
@@ -23,8 +23,8 @@ namespace SongDetailsCache {
     shared_ptr_vector<Song> SongDetailsContainer::songs;
     shared_ptr_vector<SongDifficulty> SongDetailsContainer::difficulties;
 
-    UnorderedEventCallback<> SongDetailsContainer::dataAvailableOrUpdatedInternal;
-    UnorderedEventCallback<std::string> SongDetailsContainer::dataLoadFailedInternal;
+    BSHookUtils::UnorderedEventCallback<> SongDetailsContainer::dataAvailableOrUpdatedInternal;
+    BSHookUtils::UnorderedEventCallback<std::string> SongDetailsContainer::dataLoadFailedInternal;
 
     std::future<void> SongDetailsContainer::Load(bool reload, int acceptableAgeHours) {
         return std::async(std::launch::async, std::bind(&SongDetailsContainer::Load_internal, reload, acceptableAgeHours));

--- a/src/Data/SongDetailsContainer.cpp
+++ b/src/Data/SongDetailsContainer.cpp
@@ -96,7 +96,7 @@ namespace SongDetailsCache {
 
         if (!get_isDataAvailable()) {
             // TODO: Collect the last error
-            dataLoadFailedInternal.invoke("Unknown error");
+            dataLoadFailedInternal.invoke("DB failed to download");
         }
         SongDetails::isLoading = false;
     }

--- a/src/Data/SongDifficulty.cpp
+++ b/src/Data/SongDifficulty.cpp
@@ -5,7 +5,7 @@
 
 namespace SongDetailsCache {
     const SongDifficulty SongDifficulty::none{0, nullptr};
-    SongDifficulty::SongDifficulty(std::size_t songIndex, const Structs::SongDifficultyProto* proto) noexcept :
+    SongDifficulty::SongDifficulty(std::size_t songIndex, const Structs::SongDifficulty* proto) noexcept :
         songIndex(songIndex),
         characteristic(proto && proto->has_characteristic() ? static_cast<MapCharacteristic>(proto->characteristic()) : MapCharacteristic::Standard),
         difficulty(proto && proto->has_difficulty() ? static_cast<MapDifficulty>(proto->difficulty()) : MapDifficulty::ExpertPlus),

--- a/src/Data/SongDifficulty.cpp
+++ b/src/Data/SongDifficulty.cpp
@@ -9,12 +9,12 @@ namespace SongDetailsCache {
         songIndex(songIndex),
         characteristic(proto && proto->has_characteristic() ? static_cast<MapCharacteristic>(proto->characteristic()) : MapCharacteristic::Standard),
         difficulty(proto && proto->has_difficulty() ? static_cast<MapDifficulty>(proto->difficulty()) : MapDifficulty::ExpertPlus),
-        starsSS(proto ? proto->starst100() / 100.0f : 0),
-        starsBL(proto ? proto->starst100bl() / 100.0f : 0),
+        starsSS(proto && proto->has_starst100() ? proto->starst100() / 100.0f : 0),
+        starsBL(proto && proto->has_starst100bl() ? proto->starst100bl() / 100.0f : 0),
         njs(proto ? proto->njst100() / 100.0f : 0),
-        bombs(proto ? proto->bombs() : 0),
-        notes(proto ? proto->notes() : 0),
-        obstacles(proto ? proto->obstacles() : 0),
+        bombs(proto && proto->has_bombs() ? proto->bombs() : 0),
+        notes(proto && proto->has_notes() ? proto->notes() : 0),
+        obstacles(proto && proto->has_obstacles() ? proto->obstacles() : 0),
         mods(proto && proto->has_mods() ? static_cast<MapMods>(proto->mods()) : MapMods::None)
         {}
 
@@ -32,12 +32,6 @@ namespace SongDetailsCache {
 
     bool SongDifficulty::rankedSS() const noexcept {
         return starsSS > 0 && hasFlags(song().rankedStates, RankedStates::ScoresaberRanked);
-    }
-
-    [[deprecated("This function is deprecated. It only works for scoresaber ranked difficulties and is not accurate.")]]
-    float SongDifficulty::approximatePpValue() const noexcept {
-        if (starsSS <= 0.05 || !rankedSS()) return 0;
-        return starsSS * 43.146f;
     }
 
     bool SongDifficulty::usesMods(const MapMods& usedMods) const noexcept {

--- a/src/SongDetails.cpp
+++ b/src/SongDetails.cpp
@@ -5,8 +5,8 @@
 
 namespace SongDetailsCache {
     SongDetails SongDetails::instance{};
-    UnorderedEventCallback<> SongDetails::dataAvailableOrUpdated;
-    UnorderedEventCallback<std::string> SongDetails::dataLoadFailed;
+    BSHookUtils::UnorderedEventCallback<> SongDetails::dataAvailableOrUpdated;
+    BSHookUtils::UnorderedEventCallback<std::string> SongDetails::dataLoadFailed;
 
     bool ::SongDetailsCache::SongDetails::isLoading = false;
 

--- a/src/SongDetails.cpp
+++ b/src/SongDetails.cpp
@@ -6,7 +6,7 @@
 namespace SongDetailsCache {
     SongDetails SongDetails::instance{};
     UnorderedEventCallback<> SongDetails::dataAvailableOrUpdated;
-    UnorderedEventCallback<> SongDetails::dataLoadFailed;
+    UnorderedEventCallback<std::string> SongDetails::dataLoadFailed;
 
     bool ::SongDetailsCache::SongDetails::isLoading = false;
 
@@ -33,8 +33,8 @@ namespace SongDetailsCache {
         instance.dataAvailableOrUpdated.invoke();
     }
 
-    void SongDetails::DataLoadFailed() {
-        instance.dataLoadFailed.invoke();
+    void SongDetails::DataLoadFailed(std::string message) {
+        instance.dataLoadFailed.invoke(message);
     }
 
     void SongDetails::SetCacheDirectory(std::filesystem::path path) {

--- a/src/SongProto.pb.cc
+++ b/src/SongProto.pb.cc
@@ -220,13 +220,14 @@ const char descriptor_table_protodef_SongProto_2eproto[] PROTOBUF_SECTION_VARIAB
   "\n\014_starsT100BLB\010\n\006_bombsB\010\n\006_notesB\014\n\n_o"
   "bstaclesB\007\n\005_mods*b\n\024RankedStatusBitflag"
   "s\022\014\n\010Unranked\020\000\022\014\n\010RankedSS\020\001\022\014\n\010RankedB"
-  "L\020\002\022\017\n\013QualifiedSS\020\004\022\017\n\013QualifiedBL\020\010*:\n"
-  "\013UploadFlags\022\010\n\004None\020\000\022\024\n\020VerifiedUpload"
-  "er\020\001\022\013\n\007Curated\020\002b\006proto3"
+  "L\020\002\022\017\n\013QualifiedSS\020\004\022\017\n\013QualifiedBL\020\010*S\n"
+  "\013UploadFlags\022\010\n\004None\020\000\022\016\n\nCuratedMap\020\001\022\024"
+  "\n\020VerifiedUploader\020\002\022\024\n\020HasV3Environment"
+  "\020\004b\006proto3"
   ;
 static ::_pbi::once_flag descriptor_table_SongProto_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_SongProto_2eproto = {
-    false, false, 1665, descriptor_table_protodef_SongProto_2eproto,
+    false, false, 1690, descriptor_table_protodef_SongProto_2eproto,
     "SongProto.proto",
     &descriptor_table_SongProto_2eproto_once, nullptr, 0, 3,
     schemas, file_default_instances, TableStruct_SongProto_2eproto::offsets,
@@ -327,6 +328,7 @@ bool UploadFlags_IsValid(int value) {
     case 0:
     case 1:
     case 2:
+    case 4:
       return true;
     default:
       return false;

--- a/src/SongProto.pb.cc
+++ b/src/SongProto.pb.cc
@@ -22,12 +22,57 @@ namespace _pbi = _pb::internal;
 
 namespace SongDetailsCache {
 namespace Structs {
-PROTOBUF_CONSTEXPR SongDifficultyProto::SongDifficultyProto(
+PROTOBUF_CONSTEXPR SongDetailsV3::SongDetailsV3(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.songs_)*/{}
+  , /*decltype(_impl_.taglist_)*/{}
+  , /*decltype(_impl_.songhashes_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.formatversion_)*/0u
+  , /*decltype(_impl_.scrapeendedunix_)*/0u
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct SongDetailsV3DefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SongDetailsV3DefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SongDetailsV3DefaultTypeInternal() {}
+  union {
+    SongDetailsV3 _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SongDetailsV3DefaultTypeInternal _SongDetailsV3_default_instance_;
+PROTOBUF_CONSTEXPR SongV3::SongV3(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_._has_bits_)*/{}
   , /*decltype(_impl_._cached_size_)*/{}
-  , /*decltype(_impl_.characteristic_)*/0u
-  , /*decltype(_impl_.difficulty_)*/0u
+  , /*decltype(_impl_.difficulties_)*/{}
+  , /*decltype(_impl_.songname_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.songauthorname_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.levelauthorname_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.uploadername_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.bpm_)*/0
+  , /*decltype(_impl_.upvotes_)*/0u
+  , /*decltype(_impl_.downvotes_)*/0u
+  , /*decltype(_impl_.uploadtimeunix_)*/0u
+  , /*decltype(_impl_.mapid_)*/0u
+  , /*decltype(_impl_.songdurationseconds_)*/0u
+  , /*decltype(_impl_.rankedchangeunix_)*/0u
+  , /*decltype(_impl_.rankedstatebitflags_)*/0
+  , /*decltype(_impl_.tags_)*/uint64_t{0u}
+  , /*decltype(_impl_.uploadflags_)*/0} {}
+struct SongV3DefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SongV3DefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SongV3DefaultTypeInternal() {}
+  union {
+    SongV3 _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SongV3DefaultTypeInternal _SongV3_default_instance_;
+PROTOBUF_CONSTEXPR SongDifficulty::SongDifficulty(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_._has_bits_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_.characteristic_)*/0
+  , /*decltype(_impl_.difficulty_)*/0
   , /*decltype(_impl_.starst100_)*/0u
   , /*decltype(_impl_.starst100bl_)*/0u
   , /*decltype(_impl_.njst100_)*/0u
@@ -35,177 +80,153 @@ PROTOBUF_CONSTEXPR SongDifficultyProto::SongDifficultyProto(
   , /*decltype(_impl_.notes_)*/0u
   , /*decltype(_impl_.obstacles_)*/0u
   , /*decltype(_impl_.mods_)*/0u} {}
-struct SongDifficultyProtoDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR SongDifficultyProtoDefaultTypeInternal()
+struct SongDifficultyDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SongDifficultyDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
-  ~SongDifficultyProtoDefaultTypeInternal() {}
+  ~SongDifficultyDefaultTypeInternal() {}
   union {
-    SongDifficultyProto _instance;
+    SongDifficulty _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SongDifficultyProtoDefaultTypeInternal _SongDifficultyProto_default_instance_;
-PROTOBUF_CONSTEXPR SongProto::SongProto(
-    ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_._has_bits_)*/{}
-  , /*decltype(_impl_._cached_size_)*/{}
-  , /*decltype(_impl_.difficulties_)*/{}
-  , /*decltype(_impl_.hashbytes_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.songname_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.songauthorname_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.levelauthorname_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.uploadername_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.bpm_)*/0
-  , /*decltype(_impl_.downloadcount_)*/0u
-  , /*decltype(_impl_.upvotes_)*/0u
-  , /*decltype(_impl_.downvotes_)*/0u
-  , /*decltype(_impl_.uploadtimeunix_)*/0u
-  , /*decltype(_impl_.mapid_)*/0u
-  , /*decltype(_impl_.songdurationseconds_)*/0u
-  , /*decltype(_impl_.rankedchangeunix_)*/0u
-  , /*decltype(_impl_.rankedstate_)*/0u
-  , /*decltype(_impl_.rankedstates_)*/0u} {}
-struct SongProtoDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR SongProtoDefaultTypeInternal()
-      : _instance(::_pbi::ConstantInitialized{}) {}
-  ~SongProtoDefaultTypeInternal() {}
-  union {
-    SongProto _instance;
-  };
-};
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SongProtoDefaultTypeInternal _SongProto_default_instance_;
-PROTOBUF_CONSTEXPR SongProtoContainer::SongProtoContainer(
-    ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.songs_)*/{}
-  , /*decltype(_impl_.scrapeendedtimeunix_)*/uint64_t{0u}
-  , /*decltype(_impl_.formatversion_)*/0u
-  , /*decltype(_impl_._cached_size_)*/{}} {}
-struct SongProtoContainerDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR SongProtoContainerDefaultTypeInternal()
-      : _instance(::_pbi::ConstantInitialized{}) {}
-  ~SongProtoContainerDefaultTypeInternal() {}
-  union {
-    SongProtoContainer _instance;
-  };
-};
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SongProtoContainerDefaultTypeInternal _SongProtoContainer_default_instance_;
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SongDifficultyDefaultTypeInternal _SongDifficulty_default_instance_;
 }  // namespace Structs
 }  // namespace SongDetailsCache
 static ::_pb::Metadata file_level_metadata_SongProto_2eproto[3];
-static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_SongProto_2eproto = nullptr;
+static const ::_pb::EnumDescriptor* file_level_enum_descriptors_SongProto_2eproto[4];
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_SongProto_2eproto = nullptr;
 
 const uint32_t TableStruct_SongProto_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_._has_bits_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.characteristic_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.difficulty_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.starst100_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.starst100bl_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.njst100_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.bombs_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.notes_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.obstacles_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficultyProto, _impl_.mods_),
-  0,
-  1,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  2,
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_._has_bits_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.bpm_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.downloadcount_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.upvotes_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.downvotes_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.uploadtimeunix_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.rankedchangeunix_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.mapid_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.songdurationseconds_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.hashbytes_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.songname_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.songauthorname_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.levelauthorname_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.rankedstate_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.difficulties_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.uploadername_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProto, _impl_.rankedstates_),
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  ~0u,
-  0,
-  ~0u,
-  ~0u,
-  1,
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProtoContainer, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDetailsV3, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProtoContainer, _impl_.formatversion_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProtoContainer, _impl_.scrapeendedtimeunix_),
-  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongProtoContainer, _impl_.songs_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDetailsV3, _impl_.formatversion_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDetailsV3, _impl_.scrapeendedunix_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDetailsV3, _impl_.songhashes_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDetailsV3, _impl_.songs_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDetailsV3, _impl_.taglist_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.bpm_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.upvotes_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.downvotes_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.uploadtimeunix_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.mapid_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.songdurationseconds_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.songname_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.songauthorname_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.levelauthorname_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.uploadername_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.difficulties_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.rankedchangeunix_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.rankedstatebitflags_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.tags_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongV3, _impl_.uploadflags_),
+  ~0u,
+  1,
+  2,
+  ~0u,
+  ~0u,
+  3,
+  ~0u,
+  ~0u,
+  ~0u,
+  0,
+  ~0u,
+  4,
+  5,
+  6,
+  7,
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_._has_bits_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.characteristic_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.difficulty_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.starst100_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.starst100bl_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.njst100_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.bombs_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.notes_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.obstacles_),
+  PROTOBUF_FIELD_OFFSET(::SongDetailsCache::Structs::SongDifficulty, _impl_.mods_),
+  0,
+  1,
+  2,
+  3,
+  ~0u,
+  4,
+  5,
+  6,
+  7,
 };
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, 15, -1, sizeof(::SongDetailsCache::Structs::SongDifficultyProto)},
-  { 24, 46, -1, sizeof(::SongDetailsCache::Structs::SongProto)},
-  { 62, -1, -1, sizeof(::SongDetailsCache::Structs::SongProtoContainer)},
+  { 0, -1, -1, sizeof(::SongDetailsCache::Structs::SongDetailsV3)},
+  { 11, 32, -1, sizeof(::SongDetailsCache::Structs::SongV3)},
+  { 47, 62, -1, sizeof(::SongDetailsCache::Structs::SongDifficulty)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
-  &::SongDetailsCache::Structs::_SongDifficultyProto_default_instance_._instance,
-  &::SongDetailsCache::Structs::_SongProto_default_instance_._instance,
-  &::SongDetailsCache::Structs::_SongProtoContainer_default_instance_._instance,
+  &::SongDetailsCache::Structs::_SongDetailsV3_default_instance_._instance,
+  &::SongDetailsCache::Structs::_SongV3_default_instance_._instance,
+  &::SongDetailsCache::Structs::_SongDifficulty_default_instance_._instance,
 };
 
 const char descriptor_table_protodef_SongProto_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\017SongProto.proto\022\030SongDetailsCache.Stru"
-  "cts\"\363\001\n\023SongDifficultyProto\022\033\n\016character"
-  "istic\030\001 \001(\rH\000\210\001\001\022\027\n\ndifficulty\030\002 \001(\rH\001\210\001"
-  "\001\022\021\n\tstarsT100\030\004 \001(\r\022\023\n\013starsT100BL\030\005 \001("
-  "\r\022\017\n\007njsT100\030\006 \001(\r\022\r\n\005bombs\030\007 \001(\r\022\r\n\005not"
-  "es\030\010 \001(\r\022\021\n\tobstacles\030\t \001(\r\022\021\n\004mods\030\n \001("
-  "\rH\002\210\001\001B\021\n\017_characteristicB\r\n\013_difficulty"
-  "B\007\n\005_mods\"\270\003\n\tSongProto\022\013\n\003bpm\030\001 \001(\002\022\025\n\r"
-  "downloadCount\030\002 \001(\r\022\017\n\007upvotes\030\003 \001(\r\022\021\n\t"
-  "downvotes\030\004 \001(\r\022\026\n\016uploadTimeUnix\030\005 \001(\r\022"
-  "\030\n\020rankedChangeUnix\030\016 \001(\r\022\r\n\005mapId\030\006 \001(\r"
-  "\022\033\n\023songDurationSeconds\030\010 \001(\r\022\021\n\thashByt"
-  "es\030\t \001(\014\022\020\n\010songName\030\n \001(\t\022\026\n\016songAuthor"
-  "Name\030\013 \001(\t\022\027\n\017levelAuthorName\030\014 \001(\t\022\030\n\013r"
-  "ankedState\030\017 \001(\rH\000\210\001\001\022C\n\014difficulties\030\r "
-  "\003(\0132-.SongDetailsCache.Structs.SongDiffi"
-  "cultyProto\022\024\n\014uploaderName\030\020 \001(\t\022\031\n\014rank"
-  "edStates\030\021 \001(\rH\001\210\001\001B\016\n\014_rankedStateB\017\n\r_"
-  "rankedStates\"|\n\022SongProtoContainer\022\025\n\rfo"
-  "rmatVersion\030\001 \001(\r\022\033\n\023scrapeEndedTimeUnix"
-  "\030\002 \001(\004\0222\n\005songs\030\004 \003(\0132#.SongDetailsCache"
-  ".Structs.SongProtob\006proto3"
+  "cts\"\225\001\n\rSongDetailsV3\022\025\n\rformatVersion\030\001"
+  " \001(\r\022\027\n\017scrapeEndedUnix\030\002 \001(\r\022\022\n\nsongHas"
+  "hes\030\003 \001(\014\022/\n\005songs\030\004 \003(\0132 .SongDetailsCa"
+  "che.Structs.SongV3\022\017\n\007tagList\030\005 \003(\t\"\370\004\n\006"
+  "SongV3\022\013\n\003bpm\030\001 \001(\002\022\024\n\007upvotes\030\002 \001(\rH\000\210\001"
+  "\001\022\026\n\tdownvotes\030\003 \001(\rH\001\210\001\001\022\026\n\016uploadTimeU"
+  "nix\030\004 \001(\r\022\r\n\005mapId\030\005 \001(\r\022 \n\023songDuration"
+  "Seconds\030\006 \001(\rH\002\210\001\001\022\020\n\010songName\030\007 \001(\t\022\026\n\016"
+  "songAuthorName\030\010 \001(\t\022\027\n\017levelAuthorName\030"
+  "\t \001(\t\022\031\n\014uploaderName\030\n \001(\tH\003\210\001\001\022>\n\014diff"
+  "iculties\030\013 \003(\0132(.SongDetailsCache.Struct"
+  "s.SongDifficulty\022\035\n\020rankedChangeUnix\030\014 \001"
+  "(\rH\004\210\001\001\022P\n\023rankedStateBitflags\030\r \001(\0162..S"
+  "ongDetailsCache.Structs.RankedStatusBitf"
+  "lagsH\005\210\001\001\022\021\n\004tags\030\016 \001(\004H\006\210\001\001\022\?\n\013uploadFl"
+  "ags\030\017 \001(\0162%.SongDetailsCache.Structs.Upl"
+  "oadFlagsH\007\210\001\001B\n\n\010_upvotesB\014\n\n_downvotesB"
+  "\026\n\024_songDurationSecondsB\017\n\r_uploaderName"
+  "B\023\n\021_rankedChangeUnixB\026\n\024_rankedStateBit"
+  "flagsB\007\n\005_tagsB\016\n\014_uploadFlags\"\230\005\n\016SongD"
+  "ifficulty\022W\n\016characteristic\030\001 \001(\0162:.Song"
+  "DetailsCache.Structs.SongDifficulty.MapC"
+  "haracteristicH\000\210\001\001\022O\n\ndifficulty\030\002 \001(\01626"
+  ".SongDetailsCache.Structs.SongDifficulty"
+  ".MapDifficultyH\001\210\001\001\022\026\n\tstarsT100\030\004 \001(\rH\002"
+  "\210\001\001\022\030\n\013starsT100BL\030\005 \001(\rH\003\210\001\001\022\017\n\007njsT100"
+  "\030\006 \001(\r\022\022\n\005bombs\030\007 \001(\rH\004\210\001\001\022\022\n\005notes\030\010 \001("
+  "\rH\005\210\001\001\022\026\n\tobstacles\030\t \001(\rH\006\210\001\001\022\021\n\004mods\030\n"
+  " \001(\rH\007\210\001\001\"\215\001\n\021MapCharacteristic\022\n\n\006Custo"
+  "m\020\000\022\014\n\010Standard\020\001\022\014\n\010OneSaber\020\002\022\014\n\010NoArr"
+  "ows\020\003\022\020\n\014NinetyDegree\020\004\022\024\n\020ThreeSixtyDeg"
+  "ree\020\005\022\r\n\tLightshow\020\006\022\013\n\007Lawless\020\007\"K\n\rMap"
+  "Difficulty\022\010\n\004Easy\020\000\022\n\n\006Normal\020\001\022\010\n\004Hard"
+  "\020\002\022\n\n\006Expert\020\003\022\016\n\nExpertPlus\020\004B\021\n\017_chara"
+  "cteristicB\r\n\013_difficultyB\014\n\n_starsT100B\016"
+  "\n\014_starsT100BLB\010\n\006_bombsB\010\n\006_notesB\014\n\n_o"
+  "bstaclesB\007\n\005_mods*b\n\024RankedStatusBitflag"
+  "s\022\014\n\010Unranked\020\000\022\014\n\010RankedSS\020\001\022\014\n\010RankedB"
+  "L\020\002\022\017\n\013QualifiedSS\020\004\022\017\n\013QualifiedBL\020\010*:\n"
+  "\013UploadFlags\022\010\n\004None\020\000\022\024\n\020VerifiedUpload"
+  "er\020\001\022\013\n\007Curated\020\002b\006proto3"
   ;
 static ::_pbi::once_flag descriptor_table_SongProto_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_SongProto_2eproto = {
-    false, false, 866, descriptor_table_protodef_SongProto_2eproto,
+    false, false, 1665, descriptor_table_protodef_SongProto_2eproto,
     "SongProto.proto",
     &descriptor_table_SongProto_2eproto_once, nullptr, 0, 3,
     schemas, file_default_instances, TableStruct_SongProto_2eproto::offsets,
@@ -220,32 +241,1189 @@ PROTOBUF_ATTRIBUTE_WEAK const ::_pbi::DescriptorTable* descriptor_table_SongProt
 PROTOBUF_ATTRIBUTE_INIT_PRIORITY2 static ::_pbi::AddDescriptorsRunner dynamic_init_dummy_SongProto_2eproto(&descriptor_table_SongProto_2eproto);
 namespace SongDetailsCache {
 namespace Structs {
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* SongDifficulty_MapCharacteristic_descriptor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_SongProto_2eproto);
+  return file_level_enum_descriptors_SongProto_2eproto[0];
+}
+bool SongDifficulty_MapCharacteristic_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6:
+    case 7:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#if (__cplusplus < 201703) && (!defined(_MSC_VER) || (_MSC_VER >= 1900 && _MSC_VER < 1912))
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::Custom;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::Standard;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::OneSaber;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::NoArrows;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::NinetyDegree;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::ThreeSixtyDegree;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::Lightshow;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::Lawless;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::MapCharacteristic_MIN;
+constexpr SongDifficulty_MapCharacteristic SongDifficulty::MapCharacteristic_MAX;
+constexpr int SongDifficulty::MapCharacteristic_ARRAYSIZE;
+#endif  // (__cplusplus < 201703) && (!defined(_MSC_VER) || (_MSC_VER >= 1900 && _MSC_VER < 1912))
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* SongDifficulty_MapDifficulty_descriptor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_SongProto_2eproto);
+  return file_level_enum_descriptors_SongProto_2eproto[1];
+}
+bool SongDifficulty_MapDifficulty_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#if (__cplusplus < 201703) && (!defined(_MSC_VER) || (_MSC_VER >= 1900 && _MSC_VER < 1912))
+constexpr SongDifficulty_MapDifficulty SongDifficulty::Easy;
+constexpr SongDifficulty_MapDifficulty SongDifficulty::Normal;
+constexpr SongDifficulty_MapDifficulty SongDifficulty::Hard;
+constexpr SongDifficulty_MapDifficulty SongDifficulty::Expert;
+constexpr SongDifficulty_MapDifficulty SongDifficulty::ExpertPlus;
+constexpr SongDifficulty_MapDifficulty SongDifficulty::MapDifficulty_MIN;
+constexpr SongDifficulty_MapDifficulty SongDifficulty::MapDifficulty_MAX;
+constexpr int SongDifficulty::MapDifficulty_ARRAYSIZE;
+#endif  // (__cplusplus < 201703) && (!defined(_MSC_VER) || (_MSC_VER >= 1900 && _MSC_VER < 1912))
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* RankedStatusBitflags_descriptor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_SongProto_2eproto);
+  return file_level_enum_descriptors_SongProto_2eproto[2];
+}
+bool RankedStatusBitflags_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+    case 2:
+    case 4:
+    case 8:
+      return true;
+    default:
+      return false;
+  }
+}
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* UploadFlags_descriptor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_SongProto_2eproto);
+  return file_level_enum_descriptors_SongProto_2eproto[3];
+}
+bool UploadFlags_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+    case 2:
+      return true;
+    default:
+      return false;
+  }
+}
+
 
 // ===================================================================
 
-class SongDifficultyProto::_Internal {
+class SongDetailsV3::_Internal {
  public:
-  using HasBits = decltype(std::declval<SongDifficultyProto>()._impl_._has_bits_);
+};
+
+SongDetailsV3::SongDetailsV3(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:SongDetailsCache.Structs.SongDetailsV3)
+}
+SongDetailsV3::SongDetailsV3(const SongDetailsV3& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  SongDetailsV3* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.songs_){from._impl_.songs_}
+    , decltype(_impl_.taglist_){from._impl_.taglist_}
+    , decltype(_impl_.songhashes_){}
+    , decltype(_impl_.formatversion_){}
+    , decltype(_impl_.scrapeendedunix_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.songhashes_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.songhashes_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_songhashes().empty()) {
+    _this->_impl_.songhashes_.Set(from._internal_songhashes(), 
+      _this->GetArenaForAllocation());
+  }
+  ::memcpy(&_impl_.formatversion_, &from._impl_.formatversion_,
+    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.scrapeendedunix_) -
+    reinterpret_cast<char*>(&_impl_.formatversion_)) + sizeof(_impl_.scrapeendedunix_));
+  // @@protoc_insertion_point(copy_constructor:SongDetailsCache.Structs.SongDetailsV3)
+}
+
+inline void SongDetailsV3::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.songs_){arena}
+    , decltype(_impl_.taglist_){arena}
+    , decltype(_impl_.songhashes_){}
+    , decltype(_impl_.formatversion_){0u}
+    , decltype(_impl_.scrapeendedunix_){0u}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.songhashes_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.songhashes_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+SongDetailsV3::~SongDetailsV3() {
+  // @@protoc_insertion_point(destructor:SongDetailsCache.Structs.SongDetailsV3)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void SongDetailsV3::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.songs_.~RepeatedPtrField();
+  _impl_.taglist_.~RepeatedPtrField();
+  _impl_.songhashes_.Destroy();
+}
+
+void SongDetailsV3::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void SongDetailsV3::Clear() {
+// @@protoc_insertion_point(message_clear_start:SongDetailsCache.Structs.SongDetailsV3)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.songs_.Clear();
+  _impl_.taglist_.Clear();
+  _impl_.songhashes_.ClearToEmpty();
+  ::memset(&_impl_.formatversion_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&_impl_.scrapeendedunix_) -
+      reinterpret_cast<char*>(&_impl_.formatversion_)) + sizeof(_impl_.scrapeendedunix_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SongDetailsV3::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // uint32 formatVersion = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          _impl_.formatversion_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // uint32 scrapeEndedUnix = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _impl_.scrapeendedunix_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // bytes songHashes = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_songhashes();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated .SongDetailsCache.Structs.SongV3 songs = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_songs(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<34>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated string tagList = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 42)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            auto str = _internal_add_taglist();
+            ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+            CHK_(ptr);
+            CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongDetailsV3.tagList"));
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<42>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* SongDetailsV3::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:SongDetailsCache.Structs.SongDetailsV3)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // uint32 formatVersion = 1;
+  if (this->_internal_formatversion() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(1, this->_internal_formatversion(), target);
+  }
+
+  // uint32 scrapeEndedUnix = 2;
+  if (this->_internal_scrapeendedunix() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(2, this->_internal_scrapeendedunix(), target);
+  }
+
+  // bytes songHashes = 3;
+  if (!this->_internal_songhashes().empty()) {
+    target = stream->WriteBytesMaybeAliased(
+        3, this->_internal_songhashes(), target);
+  }
+
+  // repeated .SongDetailsCache.Structs.SongV3 songs = 4;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_songs_size()); i < n; i++) {
+    const auto& repfield = this->_internal_songs(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(4, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
+  // repeated string tagList = 5;
+  for (int i = 0, n = this->_internal_taglist_size(); i < n; i++) {
+    const auto& s = this->_internal_taglist(i);
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      s.data(), static_cast<int>(s.length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "SongDetailsCache.Structs.SongDetailsV3.tagList");
+    target = stream->WriteString(5, s, target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:SongDetailsCache.Structs.SongDetailsV3)
+  return target;
+}
+
+size_t SongDetailsV3::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:SongDetailsCache.Structs.SongDetailsV3)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .SongDetailsCache.Structs.SongV3 songs = 4;
+  total_size += 1UL * this->_internal_songs_size();
+  for (const auto& msg : this->_impl_.songs_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // repeated string tagList = 5;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(_impl_.taglist_.size());
+  for (int i = 0, n = _impl_.taglist_.size(); i < n; i++) {
+    total_size += ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+      _impl_.taglist_.Get(i));
+  }
+
+  // bytes songHashes = 3;
+  if (!this->_internal_songhashes().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_songhashes());
+  }
+
+  // uint32 formatVersion = 1;
+  if (this->_internal_formatversion() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_formatversion());
+  }
+
+  // uint32 scrapeEndedUnix = 2;
+  if (this->_internal_scrapeendedunix() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_scrapeendedunix());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SongDetailsV3::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    SongDetailsV3::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SongDetailsV3::GetClassData() const { return &_class_data_; }
+
+
+void SongDetailsV3::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<SongDetailsV3*>(&to_msg);
+  auto& from = static_cast<const SongDetailsV3&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:SongDetailsCache.Structs.SongDetailsV3)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _this->_impl_.songs_.MergeFrom(from._impl_.songs_);
+  _this->_impl_.taglist_.MergeFrom(from._impl_.taglist_);
+  if (!from._internal_songhashes().empty()) {
+    _this->_internal_set_songhashes(from._internal_songhashes());
+  }
+  if (from._internal_formatversion() != 0) {
+    _this->_internal_set_formatversion(from._internal_formatversion());
+  }
+  if (from._internal_scrapeendedunix() != 0) {
+    _this->_internal_set_scrapeendedunix(from._internal_scrapeendedunix());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SongDetailsV3::CopyFrom(const SongDetailsV3& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:SongDetailsCache.Structs.SongDetailsV3)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SongDetailsV3::IsInitialized() const {
+  return true;
+}
+
+void SongDetailsV3::InternalSwap(SongDetailsV3* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  _impl_.songs_.InternalSwap(&other->_impl_.songs_);
+  _impl_.taglist_.InternalSwap(&other->_impl_.taglist_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.songhashes_, lhs_arena,
+      &other->_impl_.songhashes_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(SongDetailsV3, _impl_.scrapeendedunix_)
+      + sizeof(SongDetailsV3::_impl_.scrapeendedunix_)
+      - PROTOBUF_FIELD_OFFSET(SongDetailsV3, _impl_.formatversion_)>(
+          reinterpret_cast<char*>(&_impl_.formatversion_),
+          reinterpret_cast<char*>(&other->_impl_.formatversion_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SongDetailsV3::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_SongProto_2eproto_getter, &descriptor_table_SongProto_2eproto_once,
+      file_level_metadata_SongProto_2eproto[0]);
+}
+
+// ===================================================================
+
+class SongV3::_Internal {
+ public:
+  using HasBits = decltype(std::declval<SongV3>()._impl_._has_bits_);
+  static void set_has_upvotes(HasBits* has_bits) {
+    (*has_bits)[0] |= 2u;
+  }
+  static void set_has_downvotes(HasBits* has_bits) {
+    (*has_bits)[0] |= 4u;
+  }
+  static void set_has_songdurationseconds(HasBits* has_bits) {
+    (*has_bits)[0] |= 8u;
+  }
+  static void set_has_uploadername(HasBits* has_bits) {
+    (*has_bits)[0] |= 1u;
+  }
+  static void set_has_rankedchangeunix(HasBits* has_bits) {
+    (*has_bits)[0] |= 16u;
+  }
+  static void set_has_rankedstatebitflags(HasBits* has_bits) {
+    (*has_bits)[0] |= 32u;
+  }
+  static void set_has_tags(HasBits* has_bits) {
+    (*has_bits)[0] |= 64u;
+  }
+  static void set_has_uploadflags(HasBits* has_bits) {
+    (*has_bits)[0] |= 128u;
+  }
+};
+
+SongV3::SongV3(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:SongDetailsCache.Structs.SongV3)
+}
+SongV3::SongV3(const SongV3& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  SongV3* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){from._impl_._has_bits_}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.difficulties_){from._impl_.difficulties_}
+    , decltype(_impl_.songname_){}
+    , decltype(_impl_.songauthorname_){}
+    , decltype(_impl_.levelauthorname_){}
+    , decltype(_impl_.uploadername_){}
+    , decltype(_impl_.bpm_){}
+    , decltype(_impl_.upvotes_){}
+    , decltype(_impl_.downvotes_){}
+    , decltype(_impl_.uploadtimeunix_){}
+    , decltype(_impl_.mapid_){}
+    , decltype(_impl_.songdurationseconds_){}
+    , decltype(_impl_.rankedchangeunix_){}
+    , decltype(_impl_.rankedstatebitflags_){}
+    , decltype(_impl_.tags_){}
+    , decltype(_impl_.uploadflags_){}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.songname_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.songname_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_songname().empty()) {
+    _this->_impl_.songname_.Set(from._internal_songname(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.songauthorname_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.songauthorname_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_songauthorname().empty()) {
+    _this->_impl_.songauthorname_.Set(from._internal_songauthorname(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.levelauthorname_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.levelauthorname_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_levelauthorname().empty()) {
+    _this->_impl_.levelauthorname_.Set(from._internal_levelauthorname(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.uploadername_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.uploadername_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (from._internal_has_uploadername()) {
+    _this->_impl_.uploadername_.Set(from._internal_uploadername(), 
+      _this->GetArenaForAllocation());
+  }
+  ::memcpy(&_impl_.bpm_, &from._impl_.bpm_,
+    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.uploadflags_) -
+    reinterpret_cast<char*>(&_impl_.bpm_)) + sizeof(_impl_.uploadflags_));
+  // @@protoc_insertion_point(copy_constructor:SongDetailsCache.Structs.SongV3)
+}
+
+inline void SongV3::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_._has_bits_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , decltype(_impl_.difficulties_){arena}
+    , decltype(_impl_.songname_){}
+    , decltype(_impl_.songauthorname_){}
+    , decltype(_impl_.levelauthorname_){}
+    , decltype(_impl_.uploadername_){}
+    , decltype(_impl_.bpm_){0}
+    , decltype(_impl_.upvotes_){0u}
+    , decltype(_impl_.downvotes_){0u}
+    , decltype(_impl_.uploadtimeunix_){0u}
+    , decltype(_impl_.mapid_){0u}
+    , decltype(_impl_.songdurationseconds_){0u}
+    , decltype(_impl_.rankedchangeunix_){0u}
+    , decltype(_impl_.rankedstatebitflags_){0}
+    , decltype(_impl_.tags_){uint64_t{0u}}
+    , decltype(_impl_.uploadflags_){0}
+  };
+  _impl_.songname_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.songname_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.songauthorname_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.songauthorname_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.levelauthorname_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.levelauthorname_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.uploadername_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.uploadername_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+SongV3::~SongV3() {
+  // @@protoc_insertion_point(destructor:SongDetailsCache.Structs.SongV3)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void SongV3::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.difficulties_.~RepeatedPtrField();
+  _impl_.songname_.Destroy();
+  _impl_.songauthorname_.Destroy();
+  _impl_.levelauthorname_.Destroy();
+  _impl_.uploadername_.Destroy();
+}
+
+void SongV3::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void SongV3::Clear() {
+// @@protoc_insertion_point(message_clear_start:SongDetailsCache.Structs.SongV3)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.difficulties_.Clear();
+  _impl_.songname_.ClearToEmpty();
+  _impl_.songauthorname_.ClearToEmpty();
+  _impl_.levelauthorname_.ClearToEmpty();
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    _impl_.uploadername_.ClearNonDefaultToEmpty();
+  }
+  _impl_.bpm_ = 0;
+  if (cached_has_bits & 0x00000006u) {
+    ::memset(&_impl_.upvotes_, 0, static_cast<size_t>(
+        reinterpret_cast<char*>(&_impl_.downvotes_) -
+        reinterpret_cast<char*>(&_impl_.upvotes_)) + sizeof(_impl_.downvotes_));
+  }
+  ::memset(&_impl_.uploadtimeunix_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&_impl_.mapid_) -
+      reinterpret_cast<char*>(&_impl_.uploadtimeunix_)) + sizeof(_impl_.mapid_));
+  if (cached_has_bits & 0x000000f8u) {
+    ::memset(&_impl_.songdurationseconds_, 0, static_cast<size_t>(
+        reinterpret_cast<char*>(&_impl_.uploadflags_) -
+        reinterpret_cast<char*>(&_impl_.songdurationseconds_)) + sizeof(_impl_.uploadflags_));
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SongV3::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  _Internal::HasBits has_bits{};
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // float bpm = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 13)) {
+          _impl_.bpm_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else
+          goto handle_unusual;
+        continue;
+      // optional uint32 upvotes = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _Internal::set_has_upvotes(&has_bits);
+          _impl_.upvotes_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // optional uint32 downvotes = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
+          _Internal::set_has_downvotes(&has_bits);
+          _impl_.downvotes_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // uint32 uploadTimeUnix = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 32)) {
+          _impl_.uploadtimeunix_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // uint32 mapId = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 40)) {
+          _impl_.mapid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // optional uint32 songDurationSeconds = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 48)) {
+          _Internal::set_has_songdurationseconds(&has_bits);
+          _impl_.songdurationseconds_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // string songName = 7;
+      case 7:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 58)) {
+          auto str = _internal_mutable_songname();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongV3.songName"));
+        } else
+          goto handle_unusual;
+        continue;
+      // string songAuthorName = 8;
+      case 8:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 66)) {
+          auto str = _internal_mutable_songauthorname();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongV3.songAuthorName"));
+        } else
+          goto handle_unusual;
+        continue;
+      // string levelAuthorName = 9;
+      case 9:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 74)) {
+          auto str = _internal_mutable_levelauthorname();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongV3.levelAuthorName"));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional string uploaderName = 10;
+      case 10:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 82)) {
+          auto str = _internal_mutable_uploadername();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongV3.uploaderName"));
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated .SongDetailsCache.Structs.SongDifficulty difficulties = 11;
+      case 11:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 90)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_difficulties(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<90>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional uint32 rankedChangeUnix = 12;
+      case 12:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 96)) {
+          _Internal::set_has_rankedchangeunix(&has_bits);
+          _impl_.rankedchangeunix_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // optional .SongDetailsCache.Structs.RankedStatusBitflags rankedStateBitflags = 13;
+      case 13:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 104)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_rankedstatebitflags(static_cast<::SongDetailsCache::Structs::RankedStatusBitflags>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      // optional uint64 tags = 14;
+      case 14:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 112)) {
+          _Internal::set_has_tags(&has_bits);
+          _impl_.tags_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // optional .SongDetailsCache.Structs.UploadFlags uploadFlags = 15;
+      case 15:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 120)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_uploadflags(static_cast<::SongDetailsCache::Structs::UploadFlags>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  _impl_._has_bits_.Or(has_bits);
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* SongV3::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:SongDetailsCache.Structs.SongV3)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // float bpm = 1;
+  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
+  float tmp_bpm = this->_internal_bpm();
+  uint32_t raw_bpm;
+  memcpy(&raw_bpm, &tmp_bpm, sizeof(tmp_bpm));
+  if (raw_bpm != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteFloatToArray(1, this->_internal_bpm(), target);
+  }
+
+  // optional uint32 upvotes = 2;
+  if (_internal_has_upvotes()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(2, this->_internal_upvotes(), target);
+  }
+
+  // optional uint32 downvotes = 3;
+  if (_internal_has_downvotes()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(3, this->_internal_downvotes(), target);
+  }
+
+  // uint32 uploadTimeUnix = 4;
+  if (this->_internal_uploadtimeunix() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(4, this->_internal_uploadtimeunix(), target);
+  }
+
+  // uint32 mapId = 5;
+  if (this->_internal_mapid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(5, this->_internal_mapid(), target);
+  }
+
+  // optional uint32 songDurationSeconds = 6;
+  if (_internal_has_songdurationseconds()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(6, this->_internal_songdurationseconds(), target);
+  }
+
+  // string songName = 7;
+  if (!this->_internal_songname().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_songname().data(), static_cast<int>(this->_internal_songname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "SongDetailsCache.Structs.SongV3.songName");
+    target = stream->WriteStringMaybeAliased(
+        7, this->_internal_songname(), target);
+  }
+
+  // string songAuthorName = 8;
+  if (!this->_internal_songauthorname().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_songauthorname().data(), static_cast<int>(this->_internal_songauthorname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "SongDetailsCache.Structs.SongV3.songAuthorName");
+    target = stream->WriteStringMaybeAliased(
+        8, this->_internal_songauthorname(), target);
+  }
+
+  // string levelAuthorName = 9;
+  if (!this->_internal_levelauthorname().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_levelauthorname().data(), static_cast<int>(this->_internal_levelauthorname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "SongDetailsCache.Structs.SongV3.levelAuthorName");
+    target = stream->WriteStringMaybeAliased(
+        9, this->_internal_levelauthorname(), target);
+  }
+
+  // optional string uploaderName = 10;
+  if (_internal_has_uploadername()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_uploadername().data(), static_cast<int>(this->_internal_uploadername().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "SongDetailsCache.Structs.SongV3.uploaderName");
+    target = stream->WriteStringMaybeAliased(
+        10, this->_internal_uploadername(), target);
+  }
+
+  // repeated .SongDetailsCache.Structs.SongDifficulty difficulties = 11;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_difficulties_size()); i < n; i++) {
+    const auto& repfield = this->_internal_difficulties(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(11, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
+  // optional uint32 rankedChangeUnix = 12;
+  if (_internal_has_rankedchangeunix()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(12, this->_internal_rankedchangeunix(), target);
+  }
+
+  // optional .SongDetailsCache.Structs.RankedStatusBitflags rankedStateBitflags = 13;
+  if (_internal_has_rankedstatebitflags()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      13, this->_internal_rankedstatebitflags(), target);
+  }
+
+  // optional uint64 tags = 14;
+  if (_internal_has_tags()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(14, this->_internal_tags(), target);
+  }
+
+  // optional .SongDetailsCache.Structs.UploadFlags uploadFlags = 15;
+  if (_internal_has_uploadflags()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      15, this->_internal_uploadflags(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:SongDetailsCache.Structs.SongV3)
+  return target;
+}
+
+size_t SongV3::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:SongDetailsCache.Structs.SongV3)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .SongDetailsCache.Structs.SongDifficulty difficulties = 11;
+  total_size += 1UL * this->_internal_difficulties_size();
+  for (const auto& msg : this->_impl_.difficulties_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // string songName = 7;
+  if (!this->_internal_songname().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_songname());
+  }
+
+  // string songAuthorName = 8;
+  if (!this->_internal_songauthorname().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_songauthorname());
+  }
+
+  // string levelAuthorName = 9;
+  if (!this->_internal_levelauthorname().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_levelauthorname());
+  }
+
+  // optional string uploaderName = 10;
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_uploadername());
+  }
+
+  // float bpm = 1;
+  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
+  float tmp_bpm = this->_internal_bpm();
+  uint32_t raw_bpm;
+  memcpy(&raw_bpm, &tmp_bpm, sizeof(tmp_bpm));
+  if (raw_bpm != 0) {
+    total_size += 1 + 4;
+  }
+
+  if (cached_has_bits & 0x00000006u) {
+    // optional uint32 upvotes = 2;
+    if (cached_has_bits & 0x00000002u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_upvotes());
+    }
+
+    // optional uint32 downvotes = 3;
+    if (cached_has_bits & 0x00000004u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_downvotes());
+    }
+
+  }
+  // uint32 uploadTimeUnix = 4;
+  if (this->_internal_uploadtimeunix() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_uploadtimeunix());
+  }
+
+  // uint32 mapId = 5;
+  if (this->_internal_mapid() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_mapid());
+  }
+
+  if (cached_has_bits & 0x000000f8u) {
+    // optional uint32 songDurationSeconds = 6;
+    if (cached_has_bits & 0x00000008u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_songdurationseconds());
+    }
+
+    // optional uint32 rankedChangeUnix = 12;
+    if (cached_has_bits & 0x00000010u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_rankedchangeunix());
+    }
+
+    // optional .SongDetailsCache.Structs.RankedStatusBitflags rankedStateBitflags = 13;
+    if (cached_has_bits & 0x00000020u) {
+      total_size += 1 +
+        ::_pbi::WireFormatLite::EnumSize(this->_internal_rankedstatebitflags());
+    }
+
+    // optional uint64 tags = 14;
+    if (cached_has_bits & 0x00000040u) {
+      total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_tags());
+    }
+
+    // optional .SongDetailsCache.Structs.UploadFlags uploadFlags = 15;
+    if (cached_has_bits & 0x00000080u) {
+      total_size += 1 +
+        ::_pbi::WireFormatLite::EnumSize(this->_internal_uploadflags());
+    }
+
+  }
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SongV3::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    SongV3::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SongV3::GetClassData() const { return &_class_data_; }
+
+
+void SongV3::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<SongV3*>(&to_msg);
+  auto& from = static_cast<const SongV3&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:SongDetailsCache.Structs.SongV3)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _this->_impl_.difficulties_.MergeFrom(from._impl_.difficulties_);
+  if (!from._internal_songname().empty()) {
+    _this->_internal_set_songname(from._internal_songname());
+  }
+  if (!from._internal_songauthorname().empty()) {
+    _this->_internal_set_songauthorname(from._internal_songauthorname());
+  }
+  if (!from._internal_levelauthorname().empty()) {
+    _this->_internal_set_levelauthorname(from._internal_levelauthorname());
+  }
+  if (from._internal_has_uploadername()) {
+    _this->_internal_set_uploadername(from._internal_uploadername());
+  }
+  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
+  float tmp_bpm = from._internal_bpm();
+  uint32_t raw_bpm;
+  memcpy(&raw_bpm, &tmp_bpm, sizeof(tmp_bpm));
+  if (raw_bpm != 0) {
+    _this->_internal_set_bpm(from._internal_bpm());
+  }
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000006u) {
+    if (cached_has_bits & 0x00000002u) {
+      _this->_impl_.upvotes_ = from._impl_.upvotes_;
+    }
+    if (cached_has_bits & 0x00000004u) {
+      _this->_impl_.downvotes_ = from._impl_.downvotes_;
+    }
+    _this->_impl_._has_bits_[0] |= cached_has_bits;
+  }
+  if (from._internal_uploadtimeunix() != 0) {
+    _this->_internal_set_uploadtimeunix(from._internal_uploadtimeunix());
+  }
+  if (from._internal_mapid() != 0) {
+    _this->_internal_set_mapid(from._internal_mapid());
+  }
+  if (cached_has_bits & 0x000000f8u) {
+    if (cached_has_bits & 0x00000008u) {
+      _this->_impl_.songdurationseconds_ = from._impl_.songdurationseconds_;
+    }
+    if (cached_has_bits & 0x00000010u) {
+      _this->_impl_.rankedchangeunix_ = from._impl_.rankedchangeunix_;
+    }
+    if (cached_has_bits & 0x00000020u) {
+      _this->_impl_.rankedstatebitflags_ = from._impl_.rankedstatebitflags_;
+    }
+    if (cached_has_bits & 0x00000040u) {
+      _this->_impl_.tags_ = from._impl_.tags_;
+    }
+    if (cached_has_bits & 0x00000080u) {
+      _this->_impl_.uploadflags_ = from._impl_.uploadflags_;
+    }
+    _this->_impl_._has_bits_[0] |= cached_has_bits;
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void SongV3::CopyFrom(const SongV3& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:SongDetailsCache.Structs.SongV3)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SongV3::IsInitialized() const {
+  return true;
+}
+
+void SongV3::InternalSwap(SongV3* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  _impl_.difficulties_.InternalSwap(&other->_impl_.difficulties_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.songname_, lhs_arena,
+      &other->_impl_.songname_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.songauthorname_, lhs_arena,
+      &other->_impl_.songauthorname_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.levelauthorname_, lhs_arena,
+      &other->_impl_.levelauthorname_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.uploadername_, lhs_arena,
+      &other->_impl_.uploadername_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(SongV3, _impl_.uploadflags_)
+      + sizeof(SongV3::_impl_.uploadflags_)
+      - PROTOBUF_FIELD_OFFSET(SongV3, _impl_.bpm_)>(
+          reinterpret_cast<char*>(&_impl_.bpm_),
+          reinterpret_cast<char*>(&other->_impl_.bpm_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SongV3::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_SongProto_2eproto_getter, &descriptor_table_SongProto_2eproto_once,
+      file_level_metadata_SongProto_2eproto[1]);
+}
+
+// ===================================================================
+
+class SongDifficulty::_Internal {
+ public:
+  using HasBits = decltype(std::declval<SongDifficulty>()._impl_._has_bits_);
   static void set_has_characteristic(HasBits* has_bits) {
     (*has_bits)[0] |= 1u;
   }
   static void set_has_difficulty(HasBits* has_bits) {
     (*has_bits)[0] |= 2u;
   }
-  static void set_has_mods(HasBits* has_bits) {
+  static void set_has_starst100(HasBits* has_bits) {
     (*has_bits)[0] |= 4u;
+  }
+  static void set_has_starst100bl(HasBits* has_bits) {
+    (*has_bits)[0] |= 8u;
+  }
+  static void set_has_bombs(HasBits* has_bits) {
+    (*has_bits)[0] |= 16u;
+  }
+  static void set_has_notes(HasBits* has_bits) {
+    (*has_bits)[0] |= 32u;
+  }
+  static void set_has_obstacles(HasBits* has_bits) {
+    (*has_bits)[0] |= 64u;
+  }
+  static void set_has_mods(HasBits* has_bits) {
+    (*has_bits)[0] |= 128u;
   }
 };
 
-SongDifficultyProto::SongDifficultyProto(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+SongDifficulty::SongDifficulty(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor(arena, is_message_owned);
-  // @@protoc_insertion_point(arena_constructor:SongDetailsCache.Structs.SongDifficultyProto)
+  // @@protoc_insertion_point(arena_constructor:SongDetailsCache.Structs.SongDifficulty)
 }
-SongDifficultyProto::SongDifficultyProto(const SongDifficultyProto& from)
+SongDifficulty::SongDifficulty(const SongDifficulty& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
-  SongDifficultyProto* const _this = this; (void)_this;
+  SongDifficulty* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_._has_bits_){from._impl_._has_bits_}
     , /*decltype(_impl_._cached_size_)*/{}
@@ -263,18 +1441,18 @@ SongDifficultyProto::SongDifficultyProto(const SongDifficultyProto& from)
   ::memcpy(&_impl_.characteristic_, &from._impl_.characteristic_,
     static_cast<size_t>(reinterpret_cast<char*>(&_impl_.mods_) -
     reinterpret_cast<char*>(&_impl_.characteristic_)) + sizeof(_impl_.mods_));
-  // @@protoc_insertion_point(copy_constructor:SongDetailsCache.Structs.SongDifficultyProto)
+  // @@protoc_insertion_point(copy_constructor:SongDetailsCache.Structs.SongDifficulty)
 }
 
-inline void SongDifficultyProto::SharedCtor(
+inline void SongDifficulty::SharedCtor(
     ::_pb::Arena* arena, bool is_message_owned) {
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
       decltype(_impl_._has_bits_){}
     , /*decltype(_impl_._cached_size_)*/{}
-    , decltype(_impl_.characteristic_){0u}
-    , decltype(_impl_.difficulty_){0u}
+    , decltype(_impl_.characteristic_){0}
+    , decltype(_impl_.difficulty_){0}
     , decltype(_impl_.starst100_){0u}
     , decltype(_impl_.starst100bl_){0u}
     , decltype(_impl_.njst100_){0u}
@@ -285,8 +1463,8 @@ inline void SongDifficultyProto::SharedCtor(
   };
 }
 
-SongDifficultyProto::~SongDifficultyProto() {
-  // @@protoc_insertion_point(destructor:SongDetailsCache.Structs.SongDifficultyProto)
+SongDifficulty::~SongDifficulty() {
+  // @@protoc_insertion_point(destructor:SongDetailsCache.Structs.SongDifficulty)
   if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
   (void)arena;
     return;
@@ -294,70 +1472,74 @@ SongDifficultyProto::~SongDifficultyProto() {
   SharedDtor();
 }
 
-inline void SongDifficultyProto::SharedDtor() {
+inline void SongDifficulty::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
 }
 
-void SongDifficultyProto::SetCachedSize(int size) const {
+void SongDifficulty::SetCachedSize(int size) const {
   _impl_._cached_size_.Set(size);
 }
 
-void SongDifficultyProto::Clear() {
-// @@protoc_insertion_point(message_clear_start:SongDetailsCache.Structs.SongDifficultyProto)
+void SongDifficulty::Clear() {
+// @@protoc_insertion_point(message_clear_start:SongDetailsCache.Structs.SongDifficulty)
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
   cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000003u) {
+  if (cached_has_bits & 0x0000000fu) {
     ::memset(&_impl_.characteristic_, 0, static_cast<size_t>(
-        reinterpret_cast<char*>(&_impl_.difficulty_) -
-        reinterpret_cast<char*>(&_impl_.characteristic_)) + sizeof(_impl_.difficulty_));
+        reinterpret_cast<char*>(&_impl_.starst100bl_) -
+        reinterpret_cast<char*>(&_impl_.characteristic_)) + sizeof(_impl_.starst100bl_));
   }
-  ::memset(&_impl_.starst100_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&_impl_.obstacles_) -
-      reinterpret_cast<char*>(&_impl_.starst100_)) + sizeof(_impl_.obstacles_));
-  _impl_.mods_ = 0u;
+  _impl_.njst100_ = 0u;
+  if (cached_has_bits & 0x000000f0u) {
+    ::memset(&_impl_.bombs_, 0, static_cast<size_t>(
+        reinterpret_cast<char*>(&_impl_.mods_) -
+        reinterpret_cast<char*>(&_impl_.bombs_)) + sizeof(_impl_.mods_));
+  }
   _impl_._has_bits_.Clear();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* SongDifficultyProto::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+const char* SongDifficulty::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   _Internal::HasBits has_bits{};
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // optional uint32 characteristic = 1;
+      // optional .SongDetailsCache.Structs.SongDifficulty.MapCharacteristic characteristic = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
-          _Internal::set_has_characteristic(&has_bits);
-          _impl_.characteristic_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
+          _internal_set_characteristic(static_cast<::SongDetailsCache::Structs::SongDifficulty_MapCharacteristic>(val));
         } else
           goto handle_unusual;
         continue;
-      // optional uint32 difficulty = 2;
+      // optional .SongDetailsCache.Structs.SongDifficulty.MapDifficulty difficulty = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
-          _Internal::set_has_difficulty(&has_bits);
-          _impl_.difficulty_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
+          _internal_set_difficulty(static_cast<::SongDetailsCache::Structs::SongDifficulty_MapDifficulty>(val));
         } else
           goto handle_unusual;
         continue;
-      // uint32 starsT100 = 4;
+      // optional uint32 starsT100 = 4;
       case 4:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 32)) {
+          _Internal::set_has_starst100(&has_bits);
           _impl_.starst100_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // uint32 starsT100BL = 5;
+      // optional uint32 starsT100BL = 5;
       case 5:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 40)) {
+          _Internal::set_has_starst100bl(&has_bits);
           _impl_.starst100bl_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
           CHK_(ptr);
         } else
@@ -371,25 +1553,28 @@ const char* SongDifficultyProto::_InternalParse(const char* ptr, ::_pbi::ParseCo
         } else
           goto handle_unusual;
         continue;
-      // uint32 bombs = 7;
+      // optional uint32 bombs = 7;
       case 7:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 56)) {
+          _Internal::set_has_bombs(&has_bits);
           _impl_.bombs_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // uint32 notes = 8;
+      // optional uint32 notes = 8;
       case 8:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 64)) {
+          _Internal::set_has_notes(&has_bits);
           _impl_.notes_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // uint32 obstacles = 9;
+      // optional uint32 obstacles = 9;
       case 9:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 72)) {
+          _Internal::set_has_obstacles(&has_bits);
           _impl_.obstacles_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
           CHK_(ptr);
         } else
@@ -428,32 +1613,34 @@ failure:
 #undef CHK_
 }
 
-uint8_t* SongDifficultyProto::_InternalSerialize(
+uint8_t* SongDifficulty::_InternalSerialize(
     uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:SongDetailsCache.Structs.SongDifficultyProto)
+  // @@protoc_insertion_point(serialize_to_array_start:SongDetailsCache.Structs.SongDifficulty)
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // optional uint32 characteristic = 1;
+  // optional .SongDetailsCache.Structs.SongDifficulty.MapCharacteristic characteristic = 1;
   if (_internal_has_characteristic()) {
     target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(1, this->_internal_characteristic(), target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      1, this->_internal_characteristic(), target);
   }
 
-  // optional uint32 difficulty = 2;
+  // optional .SongDetailsCache.Structs.SongDifficulty.MapDifficulty difficulty = 2;
   if (_internal_has_difficulty()) {
     target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(2, this->_internal_difficulty(), target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      2, this->_internal_difficulty(), target);
   }
 
-  // uint32 starsT100 = 4;
-  if (this->_internal_starst100() != 0) {
+  // optional uint32 starsT100 = 4;
+  if (_internal_has_starst100()) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteUInt32ToArray(4, this->_internal_starst100(), target);
   }
 
-  // uint32 starsT100BL = 5;
-  if (this->_internal_starst100bl() != 0) {
+  // optional uint32 starsT100BL = 5;
+  if (_internal_has_starst100bl()) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteUInt32ToArray(5, this->_internal_starst100bl(), target);
   }
@@ -464,20 +1651,20 @@ uint8_t* SongDifficultyProto::_InternalSerialize(
     target = ::_pbi::WireFormatLite::WriteUInt32ToArray(6, this->_internal_njst100(), target);
   }
 
-  // uint32 bombs = 7;
-  if (this->_internal_bombs() != 0) {
+  // optional uint32 bombs = 7;
+  if (_internal_has_bombs()) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteUInt32ToArray(7, this->_internal_bombs(), target);
   }
 
-  // uint32 notes = 8;
-  if (this->_internal_notes() != 0) {
+  // optional uint32 notes = 8;
+  if (_internal_has_notes()) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteUInt32ToArray(8, this->_internal_notes(), target);
   }
 
-  // uint32 obstacles = 9;
-  if (this->_internal_obstacles() != 0) {
+  // optional uint32 obstacles = 9;
+  if (_internal_has_obstacles()) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteUInt32ToArray(9, this->_internal_obstacles(), target);
   }
@@ -492,12 +1679,12 @@ uint8_t* SongDifficultyProto::_InternalSerialize(
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:SongDetailsCache.Structs.SongDifficultyProto)
+  // @@protoc_insertion_point(serialize_to_array_end:SongDetailsCache.Structs.SongDifficulty)
   return target;
 }
 
-size_t SongDifficultyProto::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:SongDetailsCache.Structs.SongDifficultyProto)
+size_t SongDifficulty::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:SongDetailsCache.Structs.SongDifficulty)
   size_t total_size = 0;
 
   uint32_t cached_has_bits = 0;
@@ -505,1100 +1692,136 @@ size_t SongDifficultyProto::ByteSizeLong() const {
   (void) cached_has_bits;
 
   cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000003u) {
-    // optional uint32 characteristic = 1;
+  if (cached_has_bits & 0x0000000fu) {
+    // optional .SongDetailsCache.Structs.SongDifficulty.MapCharacteristic characteristic = 1;
     if (cached_has_bits & 0x00000001u) {
-      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_characteristic());
+      total_size += 1 +
+        ::_pbi::WireFormatLite::EnumSize(this->_internal_characteristic());
     }
 
-    // optional uint32 difficulty = 2;
+    // optional .SongDetailsCache.Structs.SongDifficulty.MapDifficulty difficulty = 2;
     if (cached_has_bits & 0x00000002u) {
-      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_difficulty());
+      total_size += 1 +
+        ::_pbi::WireFormatLite::EnumSize(this->_internal_difficulty());
+    }
+
+    // optional uint32 starsT100 = 4;
+    if (cached_has_bits & 0x00000004u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_starst100());
+    }
+
+    // optional uint32 starsT100BL = 5;
+    if (cached_has_bits & 0x00000008u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_starst100bl());
     }
 
   }
-  // uint32 starsT100 = 4;
-  if (this->_internal_starst100() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_starst100());
-  }
-
-  // uint32 starsT100BL = 5;
-  if (this->_internal_starst100bl() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_starst100bl());
-  }
-
   // uint32 njsT100 = 6;
   if (this->_internal_njst100() != 0) {
     total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_njst100());
   }
 
-  // uint32 bombs = 7;
-  if (this->_internal_bombs() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_bombs());
-  }
+  if (cached_has_bits & 0x000000f0u) {
+    // optional uint32 bombs = 7;
+    if (cached_has_bits & 0x00000010u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_bombs());
+    }
 
-  // uint32 notes = 8;
-  if (this->_internal_notes() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_notes());
-  }
+    // optional uint32 notes = 8;
+    if (cached_has_bits & 0x00000020u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_notes());
+    }
 
-  // uint32 obstacles = 9;
-  if (this->_internal_obstacles() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_obstacles());
-  }
+    // optional uint32 obstacles = 9;
+    if (cached_has_bits & 0x00000040u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_obstacles());
+    }
 
-  // optional uint32 mods = 10;
-  if (cached_has_bits & 0x00000004u) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_mods());
-  }
+    // optional uint32 mods = 10;
+    if (cached_has_bits & 0x00000080u) {
+      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_mods());
+    }
 
+  }
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SongDifficultyProto::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SongDifficulty::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
-    SongDifficultyProto::MergeImpl
+    SongDifficulty::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SongDifficultyProto::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SongDifficulty::GetClassData() const { return &_class_data_; }
 
 
-void SongDifficultyProto::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
-  auto* const _this = static_cast<SongDifficultyProto*>(&to_msg);
-  auto& from = static_cast<const SongDifficultyProto&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:SongDetailsCache.Structs.SongDifficultyProto)
+void SongDifficulty::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<SongDifficulty*>(&to_msg);
+  auto& from = static_cast<const SongDifficulty&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:SongDetailsCache.Structs.SongDifficulty)
   GOOGLE_DCHECK_NE(&from, _this);
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
   cached_has_bits = from._impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000003u) {
+  if (cached_has_bits & 0x0000000fu) {
     if (cached_has_bits & 0x00000001u) {
       _this->_impl_.characteristic_ = from._impl_.characteristic_;
     }
     if (cached_has_bits & 0x00000002u) {
       _this->_impl_.difficulty_ = from._impl_.difficulty_;
     }
+    if (cached_has_bits & 0x00000004u) {
+      _this->_impl_.starst100_ = from._impl_.starst100_;
+    }
+    if (cached_has_bits & 0x00000008u) {
+      _this->_impl_.starst100bl_ = from._impl_.starst100bl_;
+    }
     _this->_impl_._has_bits_[0] |= cached_has_bits;
-  }
-  if (from._internal_starst100() != 0) {
-    _this->_internal_set_starst100(from._internal_starst100());
-  }
-  if (from._internal_starst100bl() != 0) {
-    _this->_internal_set_starst100bl(from._internal_starst100bl());
   }
   if (from._internal_njst100() != 0) {
     _this->_internal_set_njst100(from._internal_njst100());
   }
-  if (from._internal_bombs() != 0) {
-    _this->_internal_set_bombs(from._internal_bombs());
-  }
-  if (from._internal_notes() != 0) {
-    _this->_internal_set_notes(from._internal_notes());
-  }
-  if (from._internal_obstacles() != 0) {
-    _this->_internal_set_obstacles(from._internal_obstacles());
-  }
-  if (cached_has_bits & 0x00000004u) {
-    _this->_internal_set_mods(from._internal_mods());
-  }
-  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-}
-
-void SongDifficultyProto::CopyFrom(const SongDifficultyProto& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:SongDetailsCache.Structs.SongDifficultyProto)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool SongDifficultyProto::IsInitialized() const {
-  return true;
-}
-
-void SongDifficultyProto::InternalSwap(SongDifficultyProto* other) {
-  using std::swap;
-  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
-  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(SongDifficultyProto, _impl_.mods_)
-      + sizeof(SongDifficultyProto::_impl_.mods_)
-      - PROTOBUF_FIELD_OFFSET(SongDifficultyProto, _impl_.characteristic_)>(
-          reinterpret_cast<char*>(&_impl_.characteristic_),
-          reinterpret_cast<char*>(&other->_impl_.characteristic_));
-}
-
-::PROTOBUF_NAMESPACE_ID::Metadata SongDifficultyProto::GetMetadata() const {
-  return ::_pbi::AssignDescriptors(
-      &descriptor_table_SongProto_2eproto_getter, &descriptor_table_SongProto_2eproto_once,
-      file_level_metadata_SongProto_2eproto[0]);
-}
-
-// ===================================================================
-
-class SongProto::_Internal {
- public:
-  using HasBits = decltype(std::declval<SongProto>()._impl_._has_bits_);
-  static void set_has_rankedstate(HasBits* has_bits) {
-    (*has_bits)[0] |= 1u;
-  }
-  static void set_has_rankedstates(HasBits* has_bits) {
-    (*has_bits)[0] |= 2u;
-  }
-};
-
-SongProto::SongProto(::PROTOBUF_NAMESPACE_ID::Arena* arena,
-                         bool is_message_owned)
-  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
-  SharedCtor(arena, is_message_owned);
-  // @@protoc_insertion_point(arena_constructor:SongDetailsCache.Structs.SongProto)
-}
-SongProto::SongProto(const SongProto& from)
-  : ::PROTOBUF_NAMESPACE_ID::Message() {
-  SongProto* const _this = this; (void)_this;
-  new (&_impl_) Impl_{
-      decltype(_impl_._has_bits_){from._impl_._has_bits_}
-    , /*decltype(_impl_._cached_size_)*/{}
-    , decltype(_impl_.difficulties_){from._impl_.difficulties_}
-    , decltype(_impl_.hashbytes_){}
-    , decltype(_impl_.songname_){}
-    , decltype(_impl_.songauthorname_){}
-    , decltype(_impl_.levelauthorname_){}
-    , decltype(_impl_.uploadername_){}
-    , decltype(_impl_.bpm_){}
-    , decltype(_impl_.downloadcount_){}
-    , decltype(_impl_.upvotes_){}
-    , decltype(_impl_.downvotes_){}
-    , decltype(_impl_.uploadtimeunix_){}
-    , decltype(_impl_.mapid_){}
-    , decltype(_impl_.songdurationseconds_){}
-    , decltype(_impl_.rankedchangeunix_){}
-    , decltype(_impl_.rankedstate_){}
-    , decltype(_impl_.rankedstates_){}};
-
-  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  _impl_.hashbytes_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.hashbytes_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_hashbytes().empty()) {
-    _this->_impl_.hashbytes_.Set(from._internal_hashbytes(), 
-      _this->GetArenaForAllocation());
-  }
-  _impl_.songname_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.songname_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_songname().empty()) {
-    _this->_impl_.songname_.Set(from._internal_songname(), 
-      _this->GetArenaForAllocation());
-  }
-  _impl_.songauthorname_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.songauthorname_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_songauthorname().empty()) {
-    _this->_impl_.songauthorname_.Set(from._internal_songauthorname(), 
-      _this->GetArenaForAllocation());
-  }
-  _impl_.levelauthorname_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.levelauthorname_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_levelauthorname().empty()) {
-    _this->_impl_.levelauthorname_.Set(from._internal_levelauthorname(), 
-      _this->GetArenaForAllocation());
-  }
-  _impl_.uploadername_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.uploadername_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_uploadername().empty()) {
-    _this->_impl_.uploadername_.Set(from._internal_uploadername(), 
-      _this->GetArenaForAllocation());
-  }
-  ::memcpy(&_impl_.bpm_, &from._impl_.bpm_,
-    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.rankedstates_) -
-    reinterpret_cast<char*>(&_impl_.bpm_)) + sizeof(_impl_.rankedstates_));
-  // @@protoc_insertion_point(copy_constructor:SongDetailsCache.Structs.SongProto)
-}
-
-inline void SongProto::SharedCtor(
-    ::_pb::Arena* arena, bool is_message_owned) {
-  (void)arena;
-  (void)is_message_owned;
-  new (&_impl_) Impl_{
-      decltype(_impl_._has_bits_){}
-    , /*decltype(_impl_._cached_size_)*/{}
-    , decltype(_impl_.difficulties_){arena}
-    , decltype(_impl_.hashbytes_){}
-    , decltype(_impl_.songname_){}
-    , decltype(_impl_.songauthorname_){}
-    , decltype(_impl_.levelauthorname_){}
-    , decltype(_impl_.uploadername_){}
-    , decltype(_impl_.bpm_){0}
-    , decltype(_impl_.downloadcount_){0u}
-    , decltype(_impl_.upvotes_){0u}
-    , decltype(_impl_.downvotes_){0u}
-    , decltype(_impl_.uploadtimeunix_){0u}
-    , decltype(_impl_.mapid_){0u}
-    , decltype(_impl_.songdurationseconds_){0u}
-    , decltype(_impl_.rankedchangeunix_){0u}
-    , decltype(_impl_.rankedstate_){0u}
-    , decltype(_impl_.rankedstates_){0u}
-  };
-  _impl_.hashbytes_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.hashbytes_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.songname_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.songname_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.songauthorname_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.songauthorname_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.levelauthorname_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.levelauthorname_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.uploadername_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.uploadername_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-}
-
-SongProto::~SongProto() {
-  // @@protoc_insertion_point(destructor:SongDetailsCache.Structs.SongProto)
-  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
-  (void)arena;
-    return;
-  }
-  SharedDtor();
-}
-
-inline void SongProto::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  _impl_.difficulties_.~RepeatedPtrField();
-  _impl_.hashbytes_.Destroy();
-  _impl_.songname_.Destroy();
-  _impl_.songauthorname_.Destroy();
-  _impl_.levelauthorname_.Destroy();
-  _impl_.uploadername_.Destroy();
-}
-
-void SongProto::SetCachedSize(int size) const {
-  _impl_._cached_size_.Set(size);
-}
-
-void SongProto::Clear() {
-// @@protoc_insertion_point(message_clear_start:SongDetailsCache.Structs.SongProto)
-  uint32_t cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  _impl_.difficulties_.Clear();
-  _impl_.hashbytes_.ClearToEmpty();
-  _impl_.songname_.ClearToEmpty();
-  _impl_.songauthorname_.ClearToEmpty();
-  _impl_.levelauthorname_.ClearToEmpty();
-  _impl_.uploadername_.ClearToEmpty();
-  ::memset(&_impl_.bpm_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&_impl_.rankedchangeunix_) -
-      reinterpret_cast<char*>(&_impl_.bpm_)) + sizeof(_impl_.rankedchangeunix_));
-  cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000003u) {
-    ::memset(&_impl_.rankedstate_, 0, static_cast<size_t>(
-        reinterpret_cast<char*>(&_impl_.rankedstates_) -
-        reinterpret_cast<char*>(&_impl_.rankedstate_)) + sizeof(_impl_.rankedstates_));
-  }
-  _impl_._has_bits_.Clear();
-  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
-}
-
-const char* SongProto::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
-#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
-  _Internal::HasBits has_bits{};
-  while (!ctx->Done(&ptr)) {
-    uint32_t tag;
-    ptr = ::_pbi::ReadTag(ptr, &tag);
-    switch (tag >> 3) {
-      // float bpm = 1;
-      case 1:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 13)) {
-          _impl_.bpm_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
-          ptr += sizeof(float);
-        } else
-          goto handle_unusual;
-        continue;
-      // uint32 downloadCount = 2;
-      case 2:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
-          _impl_.downloadcount_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // uint32 upvotes = 3;
-      case 3:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
-          _impl_.upvotes_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // uint32 downvotes = 4;
-      case 4:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 32)) {
-          _impl_.downvotes_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // uint32 uploadTimeUnix = 5;
-      case 5:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 40)) {
-          _impl_.uploadtimeunix_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // uint32 mapId = 6;
-      case 6:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 48)) {
-          _impl_.mapid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // uint32 songDurationSeconds = 8;
-      case 8:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 64)) {
-          _impl_.songdurationseconds_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // bytes hashBytes = 9;
-      case 9:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 74)) {
-          auto str = _internal_mutable_hashbytes();
-          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // string songName = 10;
-      case 10:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 82)) {
-          auto str = _internal_mutable_songname();
-          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
-          CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongProto.songName"));
-        } else
-          goto handle_unusual;
-        continue;
-      // string songAuthorName = 11;
-      case 11:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 90)) {
-          auto str = _internal_mutable_songauthorname();
-          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
-          CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongProto.songAuthorName"));
-        } else
-          goto handle_unusual;
-        continue;
-      // string levelAuthorName = 12;
-      case 12:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 98)) {
-          auto str = _internal_mutable_levelauthorname();
-          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
-          CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongProto.levelAuthorName"));
-        } else
-          goto handle_unusual;
-        continue;
-      // repeated .SongDetailsCache.Structs.SongDifficultyProto difficulties = 13;
-      case 13:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 106)) {
-          ptr -= 1;
-          do {
-            ptr += 1;
-            ptr = ctx->ParseMessage(_internal_add_difficulties(), ptr);
-            CHK_(ptr);
-            if (!ctx->DataAvailable(ptr)) break;
-          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<106>(ptr));
-        } else
-          goto handle_unusual;
-        continue;
-      // uint32 rankedChangeUnix = 14;
-      case 14:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 112)) {
-          _impl_.rankedchangeunix_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // optional uint32 rankedState = 15;
-      case 15:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 120)) {
-          _Internal::set_has_rankedstate(&has_bits);
-          _impl_.rankedstate_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // string uploaderName = 16;
-      case 16:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 130)) {
-          auto str = _internal_mutable_uploadername();
-          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
-          CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "SongDetailsCache.Structs.SongProto.uploaderName"));
-        } else
-          goto handle_unusual;
-        continue;
-      // optional uint32 rankedStates = 17;
-      case 17:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 136)) {
-          _Internal::set_has_rankedstates(&has_bits);
-          _impl_.rankedstates_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      default:
-        goto handle_unusual;
-    }  // switch
-  handle_unusual:
-    if ((tag == 0) || ((tag & 7) == 4)) {
-      CHK_(ptr);
-      ctx->SetLastTag(tag);
-      goto message_done;
+  if (cached_has_bits & 0x000000f0u) {
+    if (cached_has_bits & 0x00000010u) {
+      _this->_impl_.bombs_ = from._impl_.bombs_;
     }
-    ptr = UnknownFieldParse(
-        tag,
-        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
-        ptr, ctx);
-    CHK_(ptr != nullptr);
-  }  // while
-message_done:
-  _impl_._has_bits_.Or(has_bits);
-  return ptr;
-failure:
-  ptr = nullptr;
-  goto message_done;
-#undef CHK_
-}
-
-uint8_t* SongProto::_InternalSerialize(
-    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:SongDetailsCache.Structs.SongProto)
-  uint32_t cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // float bpm = 1;
-  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
-  float tmp_bpm = this->_internal_bpm();
-  uint32_t raw_bpm;
-  memcpy(&raw_bpm, &tmp_bpm, sizeof(tmp_bpm));
-  if (raw_bpm != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteFloatToArray(1, this->_internal_bpm(), target);
-  }
-
-  // uint32 downloadCount = 2;
-  if (this->_internal_downloadcount() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(2, this->_internal_downloadcount(), target);
-  }
-
-  // uint32 upvotes = 3;
-  if (this->_internal_upvotes() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(3, this->_internal_upvotes(), target);
-  }
-
-  // uint32 downvotes = 4;
-  if (this->_internal_downvotes() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(4, this->_internal_downvotes(), target);
-  }
-
-  // uint32 uploadTimeUnix = 5;
-  if (this->_internal_uploadtimeunix() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(5, this->_internal_uploadtimeunix(), target);
-  }
-
-  // uint32 mapId = 6;
-  if (this->_internal_mapid() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(6, this->_internal_mapid(), target);
-  }
-
-  // uint32 songDurationSeconds = 8;
-  if (this->_internal_songdurationseconds() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(8, this->_internal_songdurationseconds(), target);
-  }
-
-  // bytes hashBytes = 9;
-  if (!this->_internal_hashbytes().empty()) {
-    target = stream->WriteBytesMaybeAliased(
-        9, this->_internal_hashbytes(), target);
-  }
-
-  // string songName = 10;
-  if (!this->_internal_songname().empty()) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_songname().data(), static_cast<int>(this->_internal_songname().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "SongDetailsCache.Structs.SongProto.songName");
-    target = stream->WriteStringMaybeAliased(
-        10, this->_internal_songname(), target);
-  }
-
-  // string songAuthorName = 11;
-  if (!this->_internal_songauthorname().empty()) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_songauthorname().data(), static_cast<int>(this->_internal_songauthorname().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "SongDetailsCache.Structs.SongProto.songAuthorName");
-    target = stream->WriteStringMaybeAliased(
-        11, this->_internal_songauthorname(), target);
-  }
-
-  // string levelAuthorName = 12;
-  if (!this->_internal_levelauthorname().empty()) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_levelauthorname().data(), static_cast<int>(this->_internal_levelauthorname().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "SongDetailsCache.Structs.SongProto.levelAuthorName");
-    target = stream->WriteStringMaybeAliased(
-        12, this->_internal_levelauthorname(), target);
-  }
-
-  // repeated .SongDetailsCache.Structs.SongDifficultyProto difficulties = 13;
-  for (unsigned i = 0,
-      n = static_cast<unsigned>(this->_internal_difficulties_size()); i < n; i++) {
-    const auto& repfield = this->_internal_difficulties(i);
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
-        InternalWriteMessage(13, repfield, repfield.GetCachedSize(), target, stream);
-  }
-
-  // uint32 rankedChangeUnix = 14;
-  if (this->_internal_rankedchangeunix() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(14, this->_internal_rankedchangeunix(), target);
-  }
-
-  // optional uint32 rankedState = 15;
-  if (_internal_has_rankedstate()) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(15, this->_internal_rankedstate(), target);
-  }
-
-  // string uploaderName = 16;
-  if (!this->_internal_uploadername().empty()) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_uploadername().data(), static_cast<int>(this->_internal_uploadername().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "SongDetailsCache.Structs.SongProto.uploaderName");
-    target = stream->WriteStringMaybeAliased(
-        16, this->_internal_uploadername(), target);
-  }
-
-  // optional uint32 rankedStates = 17;
-  if (_internal_has_rankedstates()) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(17, this->_internal_rankedstates(), target);
-  }
-
-  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
-    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
-        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:SongDetailsCache.Structs.SongProto)
-  return target;
-}
-
-size_t SongProto::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:SongDetailsCache.Structs.SongProto)
-  size_t total_size = 0;
-
-  uint32_t cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  // repeated .SongDetailsCache.Structs.SongDifficultyProto difficulties = 13;
-  total_size += 1UL * this->_internal_difficulties_size();
-  for (const auto& msg : this->_impl_.difficulties_) {
-    total_size +=
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
-  }
-
-  // bytes hashBytes = 9;
-  if (!this->_internal_hashbytes().empty()) {
-    total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
-        this->_internal_hashbytes());
-  }
-
-  // string songName = 10;
-  if (!this->_internal_songname().empty()) {
-    total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-        this->_internal_songname());
-  }
-
-  // string songAuthorName = 11;
-  if (!this->_internal_songauthorname().empty()) {
-    total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-        this->_internal_songauthorname());
-  }
-
-  // string levelAuthorName = 12;
-  if (!this->_internal_levelauthorname().empty()) {
-    total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-        this->_internal_levelauthorname());
-  }
-
-  // string uploaderName = 16;
-  if (!this->_internal_uploadername().empty()) {
-    total_size += 2 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-        this->_internal_uploadername());
-  }
-
-  // float bpm = 1;
-  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
-  float tmp_bpm = this->_internal_bpm();
-  uint32_t raw_bpm;
-  memcpy(&raw_bpm, &tmp_bpm, sizeof(tmp_bpm));
-  if (raw_bpm != 0) {
-    total_size += 1 + 4;
-  }
-
-  // uint32 downloadCount = 2;
-  if (this->_internal_downloadcount() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_downloadcount());
-  }
-
-  // uint32 upvotes = 3;
-  if (this->_internal_upvotes() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_upvotes());
-  }
-
-  // uint32 downvotes = 4;
-  if (this->_internal_downvotes() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_downvotes());
-  }
-
-  // uint32 uploadTimeUnix = 5;
-  if (this->_internal_uploadtimeunix() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_uploadtimeunix());
-  }
-
-  // uint32 mapId = 6;
-  if (this->_internal_mapid() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_mapid());
-  }
-
-  // uint32 songDurationSeconds = 8;
-  if (this->_internal_songdurationseconds() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_songdurationseconds());
-  }
-
-  // uint32 rankedChangeUnix = 14;
-  if (this->_internal_rankedchangeunix() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_rankedchangeunix());
-  }
-
-  cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000003u) {
-    // optional uint32 rankedState = 15;
-    if (cached_has_bits & 0x00000001u) {
-      total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_rankedstate());
+    if (cached_has_bits & 0x00000020u) {
+      _this->_impl_.notes_ = from._impl_.notes_;
     }
-
-    // optional uint32 rankedStates = 17;
-    if (cached_has_bits & 0x00000002u) {
-      total_size += 2 +
-        ::_pbi::WireFormatLite::UInt32Size(
-          this->_internal_rankedstates());
+    if (cached_has_bits & 0x00000040u) {
+      _this->_impl_.obstacles_ = from._impl_.obstacles_;
     }
-
-  }
-  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
-}
-
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SongProto::_class_data_ = {
-    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
-    SongProto::MergeImpl
-};
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SongProto::GetClassData() const { return &_class_data_; }
-
-
-void SongProto::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
-  auto* const _this = static_cast<SongProto*>(&to_msg);
-  auto& from = static_cast<const SongProto&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:SongDetailsCache.Structs.SongProto)
-  GOOGLE_DCHECK_NE(&from, _this);
-  uint32_t cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  _this->_impl_.difficulties_.MergeFrom(from._impl_.difficulties_);
-  if (!from._internal_hashbytes().empty()) {
-    _this->_internal_set_hashbytes(from._internal_hashbytes());
-  }
-  if (!from._internal_songname().empty()) {
-    _this->_internal_set_songname(from._internal_songname());
-  }
-  if (!from._internal_songauthorname().empty()) {
-    _this->_internal_set_songauthorname(from._internal_songauthorname());
-  }
-  if (!from._internal_levelauthorname().empty()) {
-    _this->_internal_set_levelauthorname(from._internal_levelauthorname());
-  }
-  if (!from._internal_uploadername().empty()) {
-    _this->_internal_set_uploadername(from._internal_uploadername());
-  }
-  static_assert(sizeof(uint32_t) == sizeof(float), "Code assumes uint32_t and float are the same size.");
-  float tmp_bpm = from._internal_bpm();
-  uint32_t raw_bpm;
-  memcpy(&raw_bpm, &tmp_bpm, sizeof(tmp_bpm));
-  if (raw_bpm != 0) {
-    _this->_internal_set_bpm(from._internal_bpm());
-  }
-  if (from._internal_downloadcount() != 0) {
-    _this->_internal_set_downloadcount(from._internal_downloadcount());
-  }
-  if (from._internal_upvotes() != 0) {
-    _this->_internal_set_upvotes(from._internal_upvotes());
-  }
-  if (from._internal_downvotes() != 0) {
-    _this->_internal_set_downvotes(from._internal_downvotes());
-  }
-  if (from._internal_uploadtimeunix() != 0) {
-    _this->_internal_set_uploadtimeunix(from._internal_uploadtimeunix());
-  }
-  if (from._internal_mapid() != 0) {
-    _this->_internal_set_mapid(from._internal_mapid());
-  }
-  if (from._internal_songdurationseconds() != 0) {
-    _this->_internal_set_songdurationseconds(from._internal_songdurationseconds());
-  }
-  if (from._internal_rankedchangeunix() != 0) {
-    _this->_internal_set_rankedchangeunix(from._internal_rankedchangeunix());
-  }
-  cached_has_bits = from._impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000003u) {
-    if (cached_has_bits & 0x00000001u) {
-      _this->_impl_.rankedstate_ = from._impl_.rankedstate_;
-    }
-    if (cached_has_bits & 0x00000002u) {
-      _this->_impl_.rankedstates_ = from._impl_.rankedstates_;
+    if (cached_has_bits & 0x00000080u) {
+      _this->_impl_.mods_ = from._impl_.mods_;
     }
     _this->_impl_._has_bits_[0] |= cached_has_bits;
   }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void SongProto::CopyFrom(const SongProto& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:SongDetailsCache.Structs.SongProto)
+void SongDifficulty::CopyFrom(const SongDifficulty& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:SongDetailsCache.Structs.SongDifficulty)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool SongProto::IsInitialized() const {
+bool SongDifficulty::IsInitialized() const {
   return true;
 }
 
-void SongProto::InternalSwap(SongProto* other) {
+void SongDifficulty::InternalSwap(SongDifficulty* other) {
   using std::swap;
-  auto* lhs_arena = GetArenaForAllocation();
-  auto* rhs_arena = other->GetArenaForAllocation();
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
-  _impl_.difficulties_.InternalSwap(&other->_impl_.difficulties_);
-  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.hashbytes_, lhs_arena,
-      &other->_impl_.hashbytes_, rhs_arena
-  );
-  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.songname_, lhs_arena,
-      &other->_impl_.songname_, rhs_arena
-  );
-  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.songauthorname_, lhs_arena,
-      &other->_impl_.songauthorname_, rhs_arena
-  );
-  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.levelauthorname_, lhs_arena,
-      &other->_impl_.levelauthorname_, rhs_arena
-  );
-  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.uploadername_, lhs_arena,
-      &other->_impl_.uploadername_, rhs_arena
-  );
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(SongProto, _impl_.rankedstates_)
-      + sizeof(SongProto::_impl_.rankedstates_)
-      - PROTOBUF_FIELD_OFFSET(SongProto, _impl_.bpm_)>(
-          reinterpret_cast<char*>(&_impl_.bpm_),
-          reinterpret_cast<char*>(&other->_impl_.bpm_));
+      PROTOBUF_FIELD_OFFSET(SongDifficulty, _impl_.mods_)
+      + sizeof(SongDifficulty::_impl_.mods_)
+      - PROTOBUF_FIELD_OFFSET(SongDifficulty, _impl_.characteristic_)>(
+          reinterpret_cast<char*>(&_impl_.characteristic_),
+          reinterpret_cast<char*>(&other->_impl_.characteristic_));
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata SongProto::GetMetadata() const {
-  return ::_pbi::AssignDescriptors(
-      &descriptor_table_SongProto_2eproto_getter, &descriptor_table_SongProto_2eproto_once,
-      file_level_metadata_SongProto_2eproto[1]);
-}
-
-// ===================================================================
-
-class SongProtoContainer::_Internal {
- public:
-};
-
-SongProtoContainer::SongProtoContainer(::PROTOBUF_NAMESPACE_ID::Arena* arena,
-                         bool is_message_owned)
-  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
-  SharedCtor(arena, is_message_owned);
-  // @@protoc_insertion_point(arena_constructor:SongDetailsCache.Structs.SongProtoContainer)
-}
-SongProtoContainer::SongProtoContainer(const SongProtoContainer& from)
-  : ::PROTOBUF_NAMESPACE_ID::Message() {
-  SongProtoContainer* const _this = this; (void)_this;
-  new (&_impl_) Impl_{
-      decltype(_impl_.songs_){from._impl_.songs_}
-    , decltype(_impl_.scrapeendedtimeunix_){}
-    , decltype(_impl_.formatversion_){}
-    , /*decltype(_impl_._cached_size_)*/{}};
-
-  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  ::memcpy(&_impl_.scrapeendedtimeunix_, &from._impl_.scrapeendedtimeunix_,
-    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.formatversion_) -
-    reinterpret_cast<char*>(&_impl_.scrapeendedtimeunix_)) + sizeof(_impl_.formatversion_));
-  // @@protoc_insertion_point(copy_constructor:SongDetailsCache.Structs.SongProtoContainer)
-}
-
-inline void SongProtoContainer::SharedCtor(
-    ::_pb::Arena* arena, bool is_message_owned) {
-  (void)arena;
-  (void)is_message_owned;
-  new (&_impl_) Impl_{
-      decltype(_impl_.songs_){arena}
-    , decltype(_impl_.scrapeendedtimeunix_){uint64_t{0u}}
-    , decltype(_impl_.formatversion_){0u}
-    , /*decltype(_impl_._cached_size_)*/{}
-  };
-}
-
-SongProtoContainer::~SongProtoContainer() {
-  // @@protoc_insertion_point(destructor:SongDetailsCache.Structs.SongProtoContainer)
-  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
-  (void)arena;
-    return;
-  }
-  SharedDtor();
-}
-
-inline void SongProtoContainer::SharedDtor() {
-  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  _impl_.songs_.~RepeatedPtrField();
-}
-
-void SongProtoContainer::SetCachedSize(int size) const {
-  _impl_._cached_size_.Set(size);
-}
-
-void SongProtoContainer::Clear() {
-// @@protoc_insertion_point(message_clear_start:SongDetailsCache.Structs.SongProtoContainer)
-  uint32_t cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  _impl_.songs_.Clear();
-  ::memset(&_impl_.scrapeendedtimeunix_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&_impl_.formatversion_) -
-      reinterpret_cast<char*>(&_impl_.scrapeendedtimeunix_)) + sizeof(_impl_.formatversion_));
-  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
-}
-
-const char* SongProtoContainer::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
-#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
-  while (!ctx->Done(&ptr)) {
-    uint32_t tag;
-    ptr = ::_pbi::ReadTag(ptr, &tag);
-    switch (tag >> 3) {
-      // uint32 formatVersion = 1;
-      case 1:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
-          _impl_.formatversion_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // uint64 scrapeEndedTimeUnix = 2;
-      case 2:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
-          _impl_.scrapeendedtimeunix_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // repeated .SongDetailsCache.Structs.SongProto songs = 4;
-      case 4:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
-          ptr -= 1;
-          do {
-            ptr += 1;
-            ptr = ctx->ParseMessage(_internal_add_songs(), ptr);
-            CHK_(ptr);
-            if (!ctx->DataAvailable(ptr)) break;
-          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<34>(ptr));
-        } else
-          goto handle_unusual;
-        continue;
-      default:
-        goto handle_unusual;
-    }  // switch
-  handle_unusual:
-    if ((tag == 0) || ((tag & 7) == 4)) {
-      CHK_(ptr);
-      ctx->SetLastTag(tag);
-      goto message_done;
-    }
-    ptr = UnknownFieldParse(
-        tag,
-        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
-        ptr, ctx);
-    CHK_(ptr != nullptr);
-  }  // while
-message_done:
-  return ptr;
-failure:
-  ptr = nullptr;
-  goto message_done;
-#undef CHK_
-}
-
-uint8_t* SongProtoContainer::_InternalSerialize(
-    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:SongDetailsCache.Structs.SongProtoContainer)
-  uint32_t cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // uint32 formatVersion = 1;
-  if (this->_internal_formatversion() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(1, this->_internal_formatversion(), target);
-  }
-
-  // uint64 scrapeEndedTimeUnix = 2;
-  if (this->_internal_scrapeendedtimeunix() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(2, this->_internal_scrapeendedtimeunix(), target);
-  }
-
-  // repeated .SongDetailsCache.Structs.SongProto songs = 4;
-  for (unsigned i = 0,
-      n = static_cast<unsigned>(this->_internal_songs_size()); i < n; i++) {
-    const auto& repfield = this->_internal_songs(i);
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
-        InternalWriteMessage(4, repfield, repfield.GetCachedSize(), target, stream);
-  }
-
-  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
-    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
-        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:SongDetailsCache.Structs.SongProtoContainer)
-  return target;
-}
-
-size_t SongProtoContainer::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:SongDetailsCache.Structs.SongProtoContainer)
-  size_t total_size = 0;
-
-  uint32_t cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  // repeated .SongDetailsCache.Structs.SongProto songs = 4;
-  total_size += 1UL * this->_internal_songs_size();
-  for (const auto& msg : this->_impl_.songs_) {
-    total_size +=
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
-  }
-
-  // uint64 scrapeEndedTimeUnix = 2;
-  if (this->_internal_scrapeendedtimeunix() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_scrapeendedtimeunix());
-  }
-
-  // uint32 formatVersion = 1;
-  if (this->_internal_formatversion() != 0) {
-    total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_formatversion());
-  }
-
-  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
-}
-
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData SongProtoContainer::_class_data_ = {
-    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
-    SongProtoContainer::MergeImpl
-};
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*SongProtoContainer::GetClassData() const { return &_class_data_; }
-
-
-void SongProtoContainer::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
-  auto* const _this = static_cast<SongProtoContainer*>(&to_msg);
-  auto& from = static_cast<const SongProtoContainer&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:SongDetailsCache.Structs.SongProtoContainer)
-  GOOGLE_DCHECK_NE(&from, _this);
-  uint32_t cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  _this->_impl_.songs_.MergeFrom(from._impl_.songs_);
-  if (from._internal_scrapeendedtimeunix() != 0) {
-    _this->_internal_set_scrapeendedtimeunix(from._internal_scrapeendedtimeunix());
-  }
-  if (from._internal_formatversion() != 0) {
-    _this->_internal_set_formatversion(from._internal_formatversion());
-  }
-  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-}
-
-void SongProtoContainer::CopyFrom(const SongProtoContainer& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:SongDetailsCache.Structs.SongProtoContainer)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool SongProtoContainer::IsInitialized() const {
-  return true;
-}
-
-void SongProtoContainer::InternalSwap(SongProtoContainer* other) {
-  using std::swap;
-  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  _impl_.songs_.InternalSwap(&other->_impl_.songs_);
-  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(SongProtoContainer, _impl_.formatversion_)
-      + sizeof(SongProtoContainer::_impl_.formatversion_)
-      - PROTOBUF_FIELD_OFFSET(SongProtoContainer, _impl_.scrapeendedtimeunix_)>(
-          reinterpret_cast<char*>(&_impl_.scrapeendedtimeunix_),
-          reinterpret_cast<char*>(&other->_impl_.scrapeendedtimeunix_));
-}
-
-::PROTOBUF_NAMESPACE_ID::Metadata SongProtoContainer::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata SongDifficulty::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_SongProto_2eproto_getter, &descriptor_table_SongProto_2eproto_once,
       file_level_metadata_SongProto_2eproto[2]);
@@ -1608,17 +1831,17 @@ void SongProtoContainer::InternalSwap(SongProtoContainer* other) {
 }  // namespace Structs
 }  // namespace SongDetailsCache
 PROTOBUF_NAMESPACE_OPEN
-template<> PROTOBUF_NOINLINE ::SongDetailsCache::Structs::SongDifficultyProto*
-Arena::CreateMaybeMessage< ::SongDetailsCache::Structs::SongDifficultyProto >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::SongDetailsCache::Structs::SongDifficultyProto >(arena);
+template<> PROTOBUF_NOINLINE ::SongDetailsCache::Structs::SongDetailsV3*
+Arena::CreateMaybeMessage< ::SongDetailsCache::Structs::SongDetailsV3 >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::SongDetailsCache::Structs::SongDetailsV3 >(arena);
 }
-template<> PROTOBUF_NOINLINE ::SongDetailsCache::Structs::SongProto*
-Arena::CreateMaybeMessage< ::SongDetailsCache::Structs::SongProto >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::SongDetailsCache::Structs::SongProto >(arena);
+template<> PROTOBUF_NOINLINE ::SongDetailsCache::Structs::SongV3*
+Arena::CreateMaybeMessage< ::SongDetailsCache::Structs::SongV3 >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::SongDetailsCache::Structs::SongV3 >(arena);
 }
-template<> PROTOBUF_NOINLINE ::SongDetailsCache::Structs::SongProtoContainer*
-Arena::CreateMaybeMessage< ::SongDetailsCache::Structs::SongProtoContainer >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::SongDetailsCache::Structs::SongProtoContainer >(arena);
+template<> PROTOBUF_NOINLINE ::SongDetailsCache::Structs::SongDifficulty*
+Arena::CreateMaybeMessage< ::SongDetailsCache::Structs::SongDifficulty >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::SongDetailsCache::Structs::SongDifficulty >(arena);
 }
 PROTOBUF_NAMESPACE_CLOSE
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,9 +1,13 @@
 {
-    "dependencies": ["protobuf"],
+    "dependencies": ["protobuf", "brotli"],
     "overrides": [
         {
             "name": "protobuf",
             "version": "3.21.12"
+        },
+        {
+            "name": "brotli",
+            "version": "1.1.0"
         }
     ],
     "builtin-baseline": "198d68dbcc6c907cb3d0b9b1d93c3df6ecf93c62"


### PR DESCRIPTION
What's new:
- BeatSaver VerifiedUploader and Curated flags support, as well as tags
- Smaller database file size (7.96 MB -> 5.81 MB) thanks to a new schema + brotli instead of gzip
- Removed downloadCount field